### PR TITLE
Remove slow test that just exercises ActiveRecord save

### DIFF
--- a/spec/lib/dfe_data_tables/data_element_parsers/sheet_spec.rb
+++ b/spec/lib/dfe_data_tables/data_element_parsers/sheet_spec.rb
@@ -32,18 +32,6 @@ RSpec.describe 'DfEDataTables::DataElementParsers::Sheet', type: :model do
     }.to perform_under(550).ms.sample(10)
   end
 
-  it 'Will peform significantly slower (just under 12650ms) if needs saving' do
-    table = spreadsheet
-    expect {
-      table.map do |data_element|
-        next if data_element.nil?
-
-        element = DataElement.find_or_create_by(find_params(data_element))
-        element.update(update_params(data_element))
-      end
-    }.to perform_under(12650).ms.sample(10)
-  end
-
   it 'Will peform a lot better (just under 1000ms) if it bulk saves' do
     table = spreadsheet
     expect {


### PR DESCRIPTION
This was identified as a slow-running test:

```
  DfEDataTables::DataElementParsers::Sheet Will peform significantly slower (just under 12650ms) if needs saving
    67.29 seconds ./spec/lib/dfe_data_tables/data_element_parsers/sheet_spec.rb:35
```

It appears that the test proves that saving individual records is slow. This was
useful during development, but now we have the fast import it doesn't exercise
funtionality we're using