### PR TITLE
Remove require statements from lib

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'high_voltage', '~> 3.1'
 
 # I18n for models
-gem 'globalize', :github => 'spikeheap/globalize', :branch => 'check_connected'
+gem 'globalize', github: 'spikeheap/globalize', branch: 'check_connected'
 
 # Nested tree for categories
 gem 'ancestry', '~> 3.0'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,7 +36,7 @@ module ApplicationHelper
     [
       ['Recently added', 'published'],
       ['Recently updated', 'updated'],
-      ['Relevance', 'relevance'],
+      %w[Relevance relevance],
       ['A - Z', 'az']
     ]
   end

--- a/app/lib/dfe_data_tables/categories_parser.rb
+++ b/app/lib/dfe_data_tables/categories_parser.rb
@@ -31,6 +31,8 @@ module DfEDataTables
     end
 
     def categories
+      # TODO: refactor to reduce block's line count.
+      # rubocop:disable Metrics/BlockLength
       @categories ||= (1..sheet.last_row).each_with_object([]) do |idx, obj|
         row = sheet.row(idx)
         next if (idx + 1) < first_row
@@ -73,6 +75,7 @@ module DfEDataTables
 
         tree_level0[:concepts].push(concept_hash)
       end
+      # rubocop:enable Metrics/BlockLength
     end
 
   private

--- a/app/lib/dfe_data_tables/data_element_parsers/absence.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/absence.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Absence < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/alt_provision.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/alt_provision.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class AltProvision < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/ap_addresses.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/ap_addresses.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class ApAddresses < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/cin.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/cin.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Cin < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/cla.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/cla.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Cla < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/early_years_census.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/early_years_census.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class EarlyYearsCensus < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/exclusions_from2005.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/exclusions_from2005.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class ExclusionsFrom2005 < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/exclusions_up_to2005.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/exclusions_up_to2005.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class ExclusionsUpTo2005 < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/eyfsp.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/eyfsp.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Eyfsp < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/isp.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/isp.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Isp < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/ks1.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/ks1.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Ks1 < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/ks2.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/ks2.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Ks2 < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/ks3.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/ks3.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Ks3 < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/ks4.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/ks4.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Ks4 < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/ks5.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/ks5.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Ks5 < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/nccis.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/nccis.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Nccis < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/phonics.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/phonics.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Phonics < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/plams.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/plams.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Plams < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/pru_census.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/pru_census.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class PruCensus < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/sc_addresses.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/sc_addresses.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class ScAddresses < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/sc_pupil.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/sc_pupil.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class ScPupil < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/year7.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/year7.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Year7 < Sheet

--- a/app/lib/dfe_data_tables/data_element_parsers/ypmad.rb
+++ b/app/lib/dfe_data_tables/data_element_parsers/ypmad.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'sheet'
-
 module DfEDataTables
   module DataElementParsers
     class Ypmad < Sheet

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require Rails.root.join('app', 'lib', 'dfe_data_tables', 'data_elements_loader')
-
 RailsAdmin.config do |config|
   config.main_app_name = ['NPD Find & Explore']
   ### Popular gems integration

--- a/spec/lib/dfe_data_tables/data_element_parsers/sheet_spec.rb
+++ b/spec/lib/dfe_data_tables/data_element_parsers/sheet_spec.rb
@@ -23,12 +23,6 @@ RSpec.describe 'DfEDataTables::DataElementParsers::Sheet', type: :model do
     }.to perform_under(50).ms.sample(10)
   end
 
-  it 'Will perform under 550ms' do
-    table = spreadsheet
-    expect { table.map { 'do nothing' } }
-      .to perform_under(550).ms.sample(10)
-  end
-
   it 'Will peform a lot better (just under 1000ms) if it bulk saves' do
     table = spreadsheet
     expect {


### PR DESCRIPTION
These *should* auto/eager-load, so in theory we don't need to explicitly require them.

This PR resolves the following warnings:

```
/usr/src/app/app/lib/dfe_data_tables/data_element_parsers/sheet.rb:9: warning: already initialized constant DfEDataTables::DataElementParsers::Sheet::YEARS_REGEX
/usr/src/app/app/lib/dfe_data_tables/data_element_parsers/sheet.rb:9: warning: previous definition of YEARS_REGEX was here
/usr/src/app/app/lib/dfe_data_tables/data_elements_loader.rb:6: warning: already initialized constant DfEDataTables::DataElementsLoader::SHEETS
/usr/src/app/app/lib/dfe_data_tables/data_elements_loader.rb:6: warning: previous definition of SHEETS was here
```

It also fixes 4 rubocop violations, and removes an intermittently failing test which tested a noop over a map.