### PR TITLE
Dev #217: Page title for accessibility

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -6,12 +6,14 @@ class CategoriesController < ApplicationController
 
   def index
     @categories = Category.includes(:translations).roots
+    @title = t('site_title')
   end
 
   def show
     @category = Category.includes(:translations, concepts: %i[data_elements])
                         .find(params.require(:id))
 
+    @title = @category.name
     breadcrumbs_for(category_leaf: @category)
   end
 end

--- a/app/controllers/concepts_controller.rb
+++ b/app/controllers/concepts_controller.rb
@@ -9,6 +9,7 @@ class ConceptsController < ApplicationController
                .includes(:translations, :data_elements, category: [:translations])
                .find(params.require(:id))
 
+    @title = @concept.name
     breadcrumbs_for(category_leaf: @concept.category, concept: @concept)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,6 +7,10 @@ module ApplicationHelper
     sum: 'Summer'
   }.freeze
 
+  def page_title
+    [@title, 'gov.uk'].compact.join(' - ')
+  end
+
   def academic_year(year)
     return 'present' if year.blank?
 

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-xl govuk-!-width-two-thirds">
-  <%= t('site_title') %>
+  <%= @title %>
 </h1>
 
 <%= render 'shared/search_bar' %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <%= @category.name %>
+      <%= @title %>
     </h1>
 
     <p><%= @category.description %></p>

--- a/app/views/concepts/show.html.erb
+++ b/app/views/concepts/show.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <%= @concept.name %>
+      <%= @title %>
     </h1>
 
     <p><%= @concept.description || @concept.placeholder_description %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
 <head>
   <%= render 'shared/google_analytics' %>
   <meta charset="utf-8" />
-  <title>NPD Find & Explore</title>
+  <title><%= page_title %></title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#0b0c0c" />
 

--- a/app/views/pages/service_start.cy.html.erb
+++ b/app/views/pages/service_start.cy.html.erb
@@ -1,10 +1,11 @@
 <%= content_for :additional_links do %>
   <%= javascript_pack_tag 'navigation' %>
 <%- end %>
+<% @title = 'How to apply for access to NPD data' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">How to apply for access to NPD data</h1>
+    <h1 class="govuk-heading-l"><%= @title %></h1>
     <p>Cymraeg version coming soon</p>
     <hr class="govuk-section-break govuk-section-break--xl  govuk-section-break--visible ">
   </div>

--- a/app/views/pages/service_start.en.html.erb
+++ b/app/views/pages/service_start.en.html.erb
@@ -1,10 +1,11 @@
 <%= content_for :additional_links do %>
   <%= javascript_pack_tag 'navigation' %>
 <%- end %>
+<% @title = 'How to apply for access to NPD data' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">How to apply for access to NPD data</h1>
+    <h1 class="govuk-heading-l"><%= @title %></h1>
     <hr class="govuk-section-break govuk-section-break--xl  govuk-section-break--visible ">
   </div>
 


### PR DESCRIPTION
As a F&E user who uses screeneader software
I want the page title to be correct
in order to understand, broadly, what is on that page