### PR TITLE
Fix #136 fk integrity

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -66,7 +66,7 @@ module Admin
 
     def do_import
       if params['file-upload'].content_type != DfEDataTables::EXCEL_CONTENT_TYPE
-        render partial: 'form', layout: false, locals: { success: false, error: 'Please upload an Excel spreadsheet' }
+        render partial: 'import_form', layout: false, locals: { success: false, error: 'Please upload an Excel spreadsheet' }
         return
       end
 
@@ -76,10 +76,10 @@ module Admin
         DfEDataTables::CategoriesLoader.new(params['file-upload'])
       end
 
-      render partial: 'form', layout: false, locals: { success: true, error: '' }
+      render partial: 'import_form', layout: false, locals: { success: true, error: '' }
     rescue StandardError => error
       Rails.logger.error(error)
-      render partial: 'form', layout: false, locals: { success: false, error: 'There has been an error while processing your file' }
+      render partial: 'import_form', layout: false, locals: { success: false, error: 'There has been an error while processing your file' }
     end
 
   private

--- a/db/migrate/20190725111338_add_fk_to_database.rb
+++ b/db/migrate/20190725111338_add_fk_to_database.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class AddFkToDatabase < ActiveRecord::Migration[5.2]
+  def up
+    # remove orphaned translations
+    execute 'DELETE FROM category_translations WHERE category_id NOT IN (SELECT id FROM categories)'
+    execute 'DELETE FROM concept_translations WHERE concept_id NOT IN (SELECT id FROM concepts)'
+
+    # set to 'no concept' orphaned data elements
+    category = Category.find_or_create_by(name: 'No Category')
+    concept ||= Concept.find_or_create_by(name: 'No Concept', category: category)
+    DataElement.where.not(concept_id: Concept.pluck(:id)).update(concept: concept)
+
+    add_foreign_key :category_translations, :categories, uuid: true, on_delete: :cascade
+    add_foreign_key :concept_translations, :concepts, uuid: true, on_delete: :cascade
+    add_foreign_key :concepts, :categories, uuid: true, on_delete: :nullify
+    add_foreign_key :data_elements, :concepts, uuid: true, on_delete: :nullify
+  end
+
+  def down
+    remove_foreign_key :category_translations, :categories
+    remove_foreign_key :concept_translations, :concepts
+    remove_foreign_key :concepts, :categories
+    remove_foreign_key :data_elements, :concepts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_10_092723) do
+ActiveRecord::Schema.define(version: 2019_07_25_111338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -155,5 +155,9 @@ ActiveRecord::Schema.define(version: 2019_05_10_092723) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "category_translations", "categories", on_delete: :cascade
+  add_foreign_key "concept_translations", "concepts", on_delete: :cascade
+  add_foreign_key "concepts", "categories", on_delete: :nullify
+  add_foreign_key "data_elements", "concepts", on_delete: :nullify
   add_foreign_key "dfe_data_tables", "admin_users"
 end


### PR DESCRIPTION
Add migration to clean up the database and add the missing foreign keys.

What the migration does:

* remove orphaned `category_translations`
* remove orphaned `concept_translations`
* assign orphaned `data_elements` to the `No Concept` concept
* add foreign key `category_translations.category_id`
* add foreign key `concept_translations.concept_id`
* add foreign key `concepts.category_id`
* add foreign key `data_elements.concept_id`


