### PR TITLE
fix for long names pushing tables out of alignment

### DIFF
--- a/app/javascript/src/_tables.scss
+++ b/app/javascript/src/_tables.scss
@@ -4,6 +4,11 @@
   padding: 1em .5em;
 }
 
+table th:first-child {
+  word-break: break-all;
+  max-width: 400px;
+}
+
 @include govuk-media-query($until: tablet) {
   table thead {
     border: 0;


### PR DESCRIPTION
This also fixes https://github.com/DFE-Digital/npd-find-and-explore/issues/335 - Tooltip icon display issue

![image](https://user-images.githubusercontent.com/5918321/64692411-f1dfd980-d48c-11e9-8374-718f00af34ba.png)
