### PR TITLE
added fix to prevent icons wrapping

### DIFF
--- a/app/javascript/src/_tables.scss
+++ b/app/javascript/src/_tables.scss
@@ -9,6 +9,10 @@ table th:first-child {
   max-width: 400px;
 }
 
+.govuk-table__cell--numeric, .govuk-table__header--numeric {
+  white-space: nowrap;
+}
+
 @include govuk-media-query($until: tablet) {
   table thead {
     border: 0;


### PR DESCRIPTION
Fixed icons wrapping in table

![image](https://user-images.githubusercontent.com/5918321/64703020-88b79080-d4a3-11e9-8f0e-00dfd9c63bd0.png)
