### PR TITLE
added fix for tooltips whitespace

### DIFF
--- a/app/javascript/src/_tooltip.scss
+++ b/app/javascript/src/_tooltip.scss
@@ -1,6 +1,5 @@
 .tooltip {
   position: relative;
-  white-space: initial;
 
   .help {
     background-color: $govuk-brand-colour;
@@ -39,6 +38,7 @@
     transition: all .1s ease;
     width: 250px;
     z-index: 99;
+    white-space: normal;
   }
 
   .tooltip-top-left {


### PR DESCRIPTION
Modified fix... better placement of white-space rule means no inheritance for the surrounding div