### PR TITLE
IS08 - revamp my list page

### DIFF
--- a/app/controllers/saved_items_controller.rb
+++ b/app/controllers/saved_items_controller.rb
@@ -8,12 +8,7 @@ class SavedItemsController < ApplicationController
   def index
     @title = t('saved_data.my_list.title')
     @title_size = 'xl'
-    @description = t('saved_data.my_list.description',
-                     link: link_to(t('saved_data.my_list.link'),
-                                   Rails.configuration.outgoing_links.dig('applying_for_access') || '',
-                                   class: 'govuk-link',
-                                   data: { outgoing_link: true,
-                                           outgoing_page: 'Applying for Access' }))
+    @description = t('saved_data.my_list.description')
     breadcrumbs_for(custom: { name: 'My List', path: saved_items_path })
 
     render action: :index
@@ -24,15 +19,11 @@ class SavedItemsController < ApplicationController
   end
 
   def export_to_csv
-    if invalid_ranges.any?
-      render action: :index, locals: { grouped_elements: grouped_elements, range_errors: invalid_ranges }
-    else
-      filename = "NPD My List #{DateTime.now.strftime('%d-%m-%Y %H_%M')}.xlsx"
-      cookies['download'] = { value: 'download-saved-items' }
+    filename = "NPD My List #{DateTime.now.strftime('%d-%m-%Y %H_%M')}.xlsx"
+    cookies['download'] = { value: 'download-saved-items' }
 
-      render xlsx: 'export_to_csv.xlsx.axlsx', disposition: :inline, filename: filename,
-             locals: { grouped_elements: grouped_elements }
-    end
+    render xlsx: 'export_to_xlsx.xlsx.axlsx', disposition: :inline, filename: filename,
+           locals: { grouped_elements: grouped_elements }
   end
 
 private
@@ -45,19 +36,5 @@ private
     @grouped_elements ||= elements
                             &.map { |k, v| v.merge('object' => DataElement.find(k)) }
                             &.group_by { |e| e.dig(:object).datasets.first } || []
-  end
-
-  def invalid_ranges
-    current_year = Time.now.year
-    @invalid_ranges ||= begin
-                          ranges = elements.map do |_key, el|
-                            (el.dig(:years_from) || current_year) > (el.dig(:years_to) || current_year) ? range_error(el.dig(:npd_alias)) : nil
-                          end
-                          ranges.compact
-                        end
-  end
-
-  def range_error(npd_alias)
-    "#{npd_alias}: Start date must be before end date"
   end
 end

--- a/app/views/datasets/_data_element_row.html.erb
+++ b/app/views/datasets/_data_element_row.html.erb
@@ -1,9 +1,6 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__header" scope="col">
     <div class="govuk-checkboxes govuk-checkboxes--small">
-      <a href="" class="show-modal hidden">
-        <strong class="saved govuk-tag govuk-!-font-size-14">saved</strong>
-      </a>
       <div class="govuk-checkboxes__item">
         <%= check_box_tag 'data_element[]', data_element_row.title(@dataset), false,
           id: "data-element-#{data_element_row.id}", class: %w[govuk-checkboxes__input basket-checkbox],

--- a/app/views/saved_items/_element.html.erb
+++ b/app/views/saved_items/_element.html.erb
@@ -1,34 +1,66 @@
 <% data_element = element.dig(:object) %>
-<% id = element.dig(:id) %>
-<% year_from = data_element&.academic_year_collected_from || Time.now.year %>
-<% year_to = data_element&.academic_year_collected_to || Time.now.year %>
-<% years_options = (year_from..year_to).map { |y| [academic_year(y), y] } %>
+
 <tr class="govuk-table__row">
-  <th data-label="Name" class="govuk-table__header force-break" scope="row">
-    <%= link_to element.dig(:npdAlias), element.dig(:origin) %>
-    <%= hidden_field_tag "elements[#{id}][id]", id %>
-    <%= hidden_field_tag "elements[#{id}][npd_alias]", element.dig(:npdAlias) %>
+  <td class="govuk-table__header govuk-table__cell--small" scope="col">
+    <a href="remove-<%= data_element.id %>" class="item-remove" id="<%= data_element.id %>"
+        data-dataset-id="<%= dataset.id %>">
+      remove
+    </a>
+  </td>
+  <th data-label="Name" class="govuk-table__header govuk-table__cell--break" scope="row">
+    <%= hidden_field_tag "elements[#{data_element.id}][id]", data_element.id %>
+    <%= hidden_field_tag "elements[#{data_element.id}][npd_alias]", data_element.npd_alias %>
+    <%= link_to data_element.title(dataset), element.dig(:origin) %>
   </th>
+  <td data-label="Old name" class="govuk-table__cell govuk-table__cell--numeric">
+    <%= [data_element.source_old_attribute_name].join(', ') %>
+  </td>
   <td data-label="Date collected" class="govuk-table__cell govuk-table__cell--numeric">
-    <%= academic_year(year_from) %> to
-    <%= academic_year(year_to) %>
+    <%= academic_year(data_element.academic_year_collected_from) %>
+    to
+    <%= academic_year(data_element.academic_year_collected_to) %>
   </td>
-  <td data-label="Years required" class="govuk-table__cell govuk-table__cell--numeric align-left">
-    <%= select_tag "elements[#{id}][years_from]", options_for_select(years_options, element.dig(:yearFrom)),
-      include_blank: true, required: true,
-      class: %w[years-required years-required-from govuk-select govuk-!-font-size-14] %>
-    <span class="govuk-!-margin-left-2 govuk-!-margin-right-2">to</span>
-    <%= select_tag "elements[#{id}][years_to]", options_for_select(years_options, element.dig(:yearTo)),
-      include_blank: true, required: true,
-      class: %w[years-required years-required-to govuk-select govuk-!-font-size-14] %>
+  <td data-label="Sensitivity" class="govuk-table__cell govuk-table__cell--numeric">
+    <%= render 'shared/tooltip',
+      label: t('concepts.show.sensitivity.label'),
+      id: 'sensitivity-tip-before',
+      tooltip: t('concepts.show.sensitivity.tooltip') %>
+    <%= data_element&.sensitivity %>
   </td>
-  <td data-label="Additional notes" class="govuk-table__cell govuk-table__cell--numeric">
-    <%= text_field_tag "elements[#{id}][notes]", element.dig(:notes),
-      placeholder: t('saved_data.my_list.additional_notes'),
-      class: %[additional-notes govuk-input govuk-input--width-10 govuk-!-font-size-14] %>
+  <td data-label="Identification risk" class="govuk-table__cell govuk-table__cell--numeric">
+    <%= render 'shared/tooltip',
+      label: t('concepts.show.identifiability.label'),
+      id: 'identifiability-tip-before',
+      tooltip: t('concepts.show.identifiability.tooltip') %>
+    <%= data_element&.identifiability %>
   </td>
-  <td data-label="Remove" class="govuk-table__cell govuk-table__cell--numeric">
-    <a href="remove-<%= id %>" class="item-remove"
-      id="<%= id %>" data-dataset-id="<%= dataset.id %>">remove</a>
+  <td data-label="Value" class="govuk-table__cell govuk-table__cell--numeric govuk-table__cell--break">
+    <%- if /\n/ =~ data_element.values %>
+      <div class="overlay-parent">
+        <a href="#" class="codeset" aria-describedby="codeset-<%= data_element.title.downcase %>" title="Codeset for <%= data_element.title(dataset) %>">
+          Codeset<span class="codeset-specification">for <%= data_element.title(dataset) %></span>
+        </a>
+        <div class="overlay" role="overlay" id="codeset-<%= data_element.title(dataset).downcase %>">
+          <div class="overlay-content">
+            <span class="overlay-header">
+              <span>Codeset values for <%= data_element.title(dataset) %></span>
+              <a href="#" class="overlay-close">X</a>
+            </span>
+            <%- data_element.values.split("\n") do |line| %>
+              <span><%= line %></span><br />
+            <%- end %>
+          </div>
+        </div>
+      </div>
+    <%- else %>
+      <%= data_element.values %>
+    <%- end %>
+  </td>
+</tr>
+<tr class="govuk-table__row">
+  <td class="govuk-table__cell" colspan="7">
+    <p class="variable-description govuk-background__gray-4 govuk-!-font-size-16 govuk-!-margin-bottom-0">
+      <%= data_element.description %>
+    </p>
   </td>
 </tr>

--- a/app/views/saved_items/_export_bar.html.erb
+++ b/app/views/saved_items/_export_bar.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-grid-row govuk-!-margin-top-4 govuk-!-margin-bottom-4" id="copyButton">
+  <div class="govuk-grid-column-full govuk-text">
+    <button id="export-to-xlsx" name="format" value="xlsx" class="copy govuk-button govuk-!-margin-bottom-1" data-module="govuk-button">
+      Export to .xlsx file
+    </button>
+    <span class="govuk-!-margin-left-1">or</span>
+    <a href="" id="remove-all" class="govuk-!-font-size-16 govuk-!-padding-1 govuk-!-margin-bottom-1">Remove all</a>
+  </div>
+</div>

--- a/app/views/saved_items/_saved_items.html.erb
+++ b/app/views/saved_items/_saved_items.html.erb
@@ -15,6 +15,8 @@
       </div>
     <%- end %>
 
+    <%= render partial: 'export_bar' %>
+
     <%- grouped_elements.each do |dataset, group| %>
       <table class="govuk-table govuk-!-font-size-16" data-dataset-id="<%= dataset.id %>">
         <caption class="govuk-table__caption govuk-heading-m">
@@ -24,7 +26,7 @@
         <tbody class="govuk-table__body">
           <%= render partial: 'saved_items/element', collection: group, as: :element, locals: { dataset: dataset } %>
           <tr class="govuk-table__row">
-            <th data-label="Remove this dataset" class="govuk-table__header govuk-table__cell--numeric" scope="row" colspan="5">
+            <th data-label="Remove this dataset" class="govuk-table__header govuk-table__cell--numeric" scope="row" colspan="7">
               <a href="remove-dataset-<%= dataset.id %>" class="dataset-remove" id="<%= dataset.id %>">
                 Remove this dataset
               </a>
@@ -34,15 +36,7 @@
       </table>
     <%- end %>
 
-    <div class="govuk-grid-row govuk-!-margin-top-8" id="copyButton">
-      <div class="govuk-grid-column-full govuk-text">
-        <button id="export-to-csv" class="copy govuk-button govuk-!-margin-bottom-1" data-module="govuk-button">
-          Export to .xlsx file
-        </button>
-        <span class="govuk-!-margin-left-1">or</span>
-        <a href="" id="remove-all" class="govuk-!-font-size-16 govuk-!-padding-1 govuk-!-margin-bottom-1">Remove all</a>
-      </div>
-    </div>
+    <%= render partial: 'export_bar' %>
   <%- end %>
 <%- end %>
 

--- a/app/views/saved_items/_saved_items_thead.html.erb
+++ b/app/views/saved_items/_saved_items_thead.html.erb
@@ -1,13 +1,26 @@
 <thead class="govuk-table__head">
-  <tr class="govuk-table__row">
-    <th data-label="Name" class="govuk-table__header govuk-!-width-three-tenths" scope="col">Name</th>
-    <th data-label="Date collected" class="govuk-table__header govuk-table__header--numeric govuk-!-width-one-tenth" scope="col">Date collected</th>
-    <th data-label="Years required" class="govuk-table__header govuk-table__header--numeric govuk-!-width-three-tenths" scope="col">
-      Years required
+  <tr class="govuk-table__row" id="data-elements-header">
+    <th class="govuk-table__header" scope="col">
     </th>
-    <th data-label="Additional notes" class="govuk-table__header govuk-table__header--numeric govuk-!-width-two-tenths" scope="col">
-      Additional notes
+    <th data-label="Name" class="govuk-table__header" scope="col">Name</th>
+    <th data-label="Old name" class="govuk-table__header govuk-table__header--numeric" scope="col">Old name</th>
+    <th data-label="Date collected" class="govuk-table__header govuk-table__header--numeric" scope="col">Date collected</th>
+    <th data-label="Sensitivity" class="govuk-table__header govuk-table__header--numeric" scope="col">
+      <%= t('concepts.show.sensitivity.label') %>
+      <%= render 'shared/tooltip',
+        label: t('concepts.show.sensitivity.label'),
+        id: 'sensitivity-tip',
+        tooltip: t('concepts.show.sensitivity.tooltip'),
+        position: 'bottom-left' %>
     </th>
-    <th data-label="Remove" class="govuk-table__header govuk-!-width-one-tenth" scope="col"></th>
+    <th data-label="Identification risk" class="govuk-table__header govuk-table__header--numeric" scope="col">
+      <%= t('concepts.show.identifiability.label') %>
+      <%= render 'shared/tooltip',
+        label: t('concepts.show.identifiability.label'),
+        id: 'identifiability-tip',
+        tooltip: t('concepts.show.identifiability.tooltip'),
+        position: 'bottom-right' %>
+    </th>
+    <th data-label="Value" class="govuk-table__header govuk-table__header--numeric" scope="col">Values</th>
   </tr>
 </thead>

--- a/app/views/saved_items/export_to_xlsx.xlsx.axlsx
+++ b/app/views/saved_items/export_to_xlsx.xlsx.axlsx
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 wb = xlsx_package.workbook
-headers = ['Dataset', 'NPD Alias', 'Date Collected', 'Sensitivity', 'Identifiability',
-           'Years required', 'Notes']
+headers = ['Dataset', 'NPD Alias', 'Date Collected', 'Sensitivity',
+           'Identifiability', 'Notes']
 title = wb.styles.add_style(b: true)
 
 grouped_elements.each do |dataset, elements|
@@ -14,10 +14,10 @@ grouped_elements.each do |dataset, elements|
       sheet.add_row [
         dataset.tab_name,
         de.npd_alias,
-        "#{academic_year(de.academic_year_collected_from)} to #{academic_year(de.academic_year_collected_to)}",
+        [academic_year(de.academic_year_collected_from),
+         academic_year(de.academic_year_collected_to)].join(' to '),
         de.sensitivity,
         de.identifiability,
-        "#{academic_year(element['years_from'].to_i)} to #{academic_year(element['years_to'].to_i)}",
         element['notes']
       ].flatten
     end

--- a/app/views/saved_items/index.html.erb
+++ b/app/views/saved_items/index.html.erb
@@ -3,7 +3,6 @@
   <%= javascript_pack_tag 'saved_items_loader' %>
 <%- end %>
 
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-!-margin-bottom-4">
     <div class="saved_items_table govuk-text">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,15 +85,14 @@ en:
     panel: My list
     my_list:
       title: My list
-      # description: You can export these data elements into a .xlsx file. If you’re %{link} to DfE data, please attach the file to an email along with your completed application form.</p><p>Please complete the <strong>‘Years required’</strong> fields and then click <strong>‘Export to .xlsx file’</strong>.
-      description: You can export these data elements into a .xlsx file.
+      description: You can export this list of data elements into a .xlsx file.
       link: applying for access
       no_elements: You currently have no elements saved in your list
       additional_notes: Additional notes
     button: Save to my list
     instructions: You can use the checkboxes below to add data elements to your list
     copy_title: Saved in this session
-    copy_instructions: These elements will disappear when you clear your cookies for this site or by selecting 'Remove all' below. You can output them by clicking 'Export to .xlsx file'.
+    copy_instructions: This list of data elements will disappear when you clear your cookies for this site or by selecting 'Remove all' below.
 
   views:
     pagination:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,7 +85,8 @@ en:
     panel: My list
     my_list:
       title: My list
-      description: You can export these data elements into a .xlsx file. If you’re %{link} to DfE data, please attach the file to an email along with your completed application form.</p><p>Please complete the <strong>‘Years required’</strong> fields and then click <strong>‘Export to .xlsx file’</strong>.
+      # description: You can export these data elements into a .xlsx file. If you’re %{link} to DfE data, please attach the file to an email along with your completed application form.</p><p>Please complete the <strong>‘Years required’</strong> fields and then click <strong>‘Export to .xlsx file’</strong>.
+      description: You can export these data elements into a .xlsx file.
       link: applying for access
       no_elements: You currently have no elements saved in your list
       additional_notes: Additional notes

--- a/spec/system/saved_items_page_spec.rb
+++ b/spec/system/saved_items_page_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Saved Items page', type: :system do
   it 'Will show the saved items page' do
     visit '/saved_items'
     expect(page).to have_text('My list', count: 1)
-    expect(page).to have_text('You can export these data elements into a .xlsx file.')
+    expect(page).to have_text('You can export this list of data elements into a .xlsx file.')
   end
 
   context 'with saved items' do


### PR DESCRIPTION
# Required Change

The My List page needs to be amended.

The changes that have been implemented are:

* Provide all the metadata provided in the "concept" and "dataset" detail pages.
* Remove the requirement for the "years required" information.
* Where a data item is available up to the current time, the My List should state 'to present', and not 2019-20 or 2020-21.
* Duplicate the "export" and "remove all" calls to action to the top of the page.
* Amend the wording to remove any mention of the application process.

## Screenshots

### Before:

<img width="798" alt="IS08-my-list-before" src="https://user-images.githubusercontent.com/2742327/87569997-d999a600-c6bf-11ea-8cd2-e8c68a244915.png">

### After:

<img width="798" alt="IS08-my-list-after" src="https://user-images.githubusercontent.com/2742327/87570020-e1594a80-c6bf-11ea-993c-7a86274230fe.png">
