### PR TITLE
IS01 - Cookies Choice

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,4 +64,14 @@ module ApplicationHelper
   def cookie_choice_page?
     params[:controller] == 'high_voltage/pages' && params[:id] == 'cookie-preferences'
   end
+
+  def usage_cookies_allowed?
+    cookies_policy = begin
+                       JSON.parse(cookies['cookies_policy'])
+                     rescue
+                       { 'essential' => true, 'usage' => false }
+                     end
+
+    cookies_policy['usage']
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,4 +60,8 @@ module ApplicationHelper
   def shared_header?
     params[:controller] != 'high_voltage/pages'
   end
+
+  def cookie_choice_page?
+    params[:controller] == 'high_voltage/pages' && params[:id] == 'cookie-preferences'
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,7 +67,7 @@ module ApplicationHelper
 
   def usage_cookies_allowed?
     cookies_policy = begin
-                       JSON.parse(cookies['cookies_policy'])
+                       JSON.parse(cookies['cookies_policy'] || 'INVALID')
                      rescue JSON::ParserError
                        { 'essential' => true, 'usage' => false }
                      end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,7 +68,7 @@ module ApplicationHelper
   def usage_cookies_allowed?
     cookies_policy = begin
                        JSON.parse(cookies['cookies_policy'])
-                     rescue
+                     rescue JSON::ParserError
                        { 'essential' => true, 'usage' => false }
                      end
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,3 +10,6 @@
 import '../src/application.scss'
 
 import '../src/govuk-frontend.js'
+import { initCookies } from '../src/cookies.js'
+
+initCookies()

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -359,3 +359,12 @@ $govuk-assets-path: '../../../node_modules/govuk-frontend/govuk/assets/';
 .app-contact-panel__body:last-child {
   margin-bottom: 0
 }
+
+.success-message {
+  border: 5px;
+  border-style: solid;
+  border-color: #28a197;
+  padding: 20px;
+  margin-bottom: 50px;
+  margin-top: 16px;
+}

--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -366,5 +366,5 @@ $govuk-assets-path: '../../../node_modules/govuk-frontend/govuk/assets/';
   border-color: #28a197;
   padding: 20px;
   margin-bottom: 50px;
-  margin-top: 16px;
+  margin-top: 6px;
 }

--- a/app/javascript/src/cookies.js
+++ b/app/javascript/src/cookies.js
@@ -66,7 +66,7 @@ var cookiePreferencesSubmit = (function($) {
     setCookie('cookies_preferences_set', 'true');
     $('.success-message').show();
     $('html, body').animate({
-      scrollTop: $('.success-message').offset().top
+      scrollTop: $('header.govuk-header').offset().top
     });
   }
 })($);

--- a/app/javascript/src/cookies.js
+++ b/app/javascript/src/cookies.js
@@ -1,0 +1,108 @@
+import $ from 'jquery'
+
+function unwrapCookies() {
+  var allCookies = (!document.cookie ? [] : document.cookie.split(';'));
+  var cookies = {};
+
+  for (var i = 0; i < allCookies.length; i++) {
+    var cookie = allCookies[i].split('=');
+    cookies[cookie[0].replace(/^ +/g, '').replace(/ +$/g, '')] = cookie[1];
+  }
+  return cookies;
+}
+
+function getCookie(cookie) {
+  var cookies = unwrapCookies();
+
+  return cookies[cookie];
+}
+
+function setCookie(cookie, value) {
+  document.cookie = [cookie, value].join('=');
+}
+
+// Closure to make sure the $ function is the jQuery one
+var hideConfirmation = (function ($) {
+  return function() {
+    $('.gem-c-cookie-banner__confirmation').hide();
+    $('.gem-c-cookie-banner').hide();
+  }
+})($);
+
+// Closure to make sure the $ function is the jQuery one
+var initUsageChoice = (function ($) {
+  return function() {
+    var cookiesPolicy = getCookie('cookies_policy');
+
+    try {
+      cookiesPolicy = JSON.parse(cookiesPolicy);
+    } catch(error) {
+      cookiesPolicy = null;
+    }
+
+    if (cookiesPolicy && (cookiesPolicy.usage == true || cookiesPolicy.usage == 'true' || cookiesPolicy.usage == 1)) {
+      $('input[type="radio"][value="on"]').attr('checked', true);
+    } else {
+      $('input[type="radio"][value="off"]').attr('checked', true);
+    }
+  }
+})($);
+
+// Closure to make sure the $ function is the jQuery one
+var cookiePreferencesSubmit = (function($) {
+  return function (event) {
+    event.preventDefault();
+    var status = { 'on': 'true', 'off': 'false' };
+    var radios = $(event.target).find('input[type="radio"][name="survey"]')
+    var usage = 'false';
+
+    for (var i = 0; i < radios.length; i++) {
+      if (radios[i].checked) {
+        usage = status[radios[i].value];
+      }
+    }
+
+    setCookie('cookies_policy', '{"essential":true,"usage":' + usage + '}');
+    setCookie('cookies_preferences_set', 'true');
+    $('.success-message').show();
+    $('html, body').animate({
+      scrollTop: $('.success-message').offset().top
+    });
+  }
+})($);
+
+// Closure to make sure the $ function is the jQuery one
+var acceptAllCookies = (function($) {
+  return function() {
+    setCookie('cookies_policy', '{"essential":true,"usage":true}');
+    setCookie('cookies_preferences_set', 'true');
+    $('.gem-c-cookie-banner__confirmation').show();
+    $('.gem-c-cookie-banner__wrapper').hide();
+  }
+})($);
+
+// Closure to make sure the $ function is the jQuery one
+var initCookies = (function($) {
+  return function() {
+    var preferencesSet = getCookie('cookies_preferences_set');
+
+    if ($('#cookie-manager-form').length) {
+      $('.success-message').hide();
+      initUsageChoice();
+      $('#cookie-manager-form').submit(cookiePreferencesSubmit);
+    } else {
+      if (!preferencesSet) {
+        $('.gem-c-cookie-banner__confirmation').hide();
+        $('.gem-c-cookie-banner__button-accept').click(acceptAllCookies);
+        $('.gem-c-cookie-banner__hide-button').click(hideConfirmation);
+        setCookie('cookies_policy', '{"essential":true,"usage":false}');
+      } else {
+        $('.gem-c-cookie-banner__confirmation').hide();
+        $('.gem-c-cookie-banner__wrapper').hide();
+        $('.gem-c-cookie-banner').hide();
+      }
+    }
+  }
+})($);
+
+export { setCookie, initCookies }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,14 @@
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
   <%- end %>
 
-  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+  <div id="skiplink-container">
+    <div>
+      <a href="#main-content" class="skiplink govuk-skip-link">Skip to main content</a>
+    </div>
+  </div>
+  <!-- <a href="#main-content" class="govuk-skip-link">Skip to main content</a> -->
+
+  <%= render 'shared/cookie_banner' unless cookie_choice_page? %>
 
   <%= render 'shared/govuk_header' %>
 

--- a/app/views/pages/cookie-preferences.html.erb
+++ b/app/views/pages/cookie-preferences.html.erb
@@ -88,9 +88,9 @@
 
     <h2 class="govuk-heading-l">Third-party and government services</h2>
 
-    <p>Some services we link to are run by different government departments. We also use Google Forms to collect feedback comments.</p>
+    <p>NPD Find & Explore includes some links to other services and government departments. We also use Google Forms to collect feedback comments.</p>
 
-    <p>These services may set additional cookies and, if so, will have their own cookies policy.</p>
+    <p>These services may set additional cookies and, if so, will have their own cookie policy and banner linking to it.</p>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/pages/cookie-preferences.html.erb
+++ b/app/views/pages/cookie-preferences.html.erb
@@ -1,0 +1,113 @@
+<%= content_for :additional_links do %>
+  <%= javascript_pack_tag 'navigation' %>
+<%- end %>
+
+<% @title = 'Cookies on Find and Explore NPD Data' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="success-message" aria-labelledby="success-title" role="alert" tabindex="-1">
+      <h2 class="success-title govuk-heading-m">
+        Your cookie settings were saved
+      </h2>
+      <div>
+        <p>Government services may set additional cookies and, if so, will have their own cookie policy and banner.</p>
+      </div>
+      <a href="/">Go to homepage</a>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= @title %>
+    </h1>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p>Cookies are files saved on your phone, tablet or computer when you visit a website.</p>
+
+    <p>We use cookies to store information about how you use the NPD Find and Explore service, such as the pages you visit.</p>
+
+    <h2 class="govuk-heading-l">Cookie settings</h2>
+
+    <p>We use 2 types of cookie. You can choose which cookies you're happy for us to use.</p>
+
+    <form id="cookie-manager-form">
+      <div class="govuk-form-group">
+        <h3 class="govuk-heading-m">Cookies that measure website use</h3>
+
+        <p>We use Google Analytics software to collect information about how you use the NPD Find and Explore service. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.</p>
+
+        <p>Google Analytics stores information about:</p>
+
+        <ul class="list-bullet">
+          <li><p>the pages you visit on the NPD Find and Explore service</p></li>
+          <li><p>how long you spend on each page</p></li>
+          <li><p>how you got to the site</p></li>
+          <li><p>what you click on while you're visiting the site</p></li>
+        </ul>
+
+        <p>Google does not collect or store your personal information, for example your name or address, so this information can't be used to identify who you are. We don't allow Google to use or share our analytics data.</p>
+
+        <div class="govuk-radios govuk-radios--inline">
+          <div class="govuk-radios__item">
+            <input type="radio" name="survey" id="radio-survey-on" value="on" class="govuk-radios__input">
+            <label for="radio-survey-on" class="govuk-label govuk-radios__label">
+              <span>On</span>
+            </label>
+          </div>
+          <div class="govuk-radios__item">
+            <input type="radio" name="survey" id="radio-survey-off" value="off" class="govuk-radios__input">
+            <label for="radio-survey-off" class="govuk-label govuk-radios__label">
+              <span>Off</span>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div class="govuk-form-group">
+        <h3 class="govuk-heading-m">Strictly necessary cookies</h3>
+
+        <p>The NPD Find and Explore service uses cookies for session management and security.</p>
+
+        <p>They always need to be on.<p>
+
+        <p>
+          <%= link_to 'Find out more about cookies on the NPD Find and Explore service', page_path(:cookies) %>
+        </p>
+      </div>
+
+      <div class="govuk-form-group">
+        <button class="govuk-button" type="submit">Save changes</button>
+      </div>
+    </form>
+
+    <h2 class="govuk-heading-l">Third-party and government services</h2>
+
+    <p>Some services we link to are run by different government departments. We also use Google Forms to collect feedback comments.</p>
+
+    <p>These services may set additional cookies and, if so, will have their own cookies policy.</p>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <aside class="app-related-items" role="complementary">
+      <h2 class="govuk-heading-s" id="subsection-title">
+        Related content
+      </h2>
+      <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-related_items-e0133a5f" data-module="gem-toggle">
+        <ul class="gem-c-related-navigation__link-list govuk-list govuk-!-font-size-16" data-module="track-click">
+          <li><%= link_to 'Cookies', page_path(:cookies) %></li>
+        </ul>
+      </nav>
+      <nav role="navigation" class="gem-c-related-navigation__nav-section" aria-labelledby="related-nav-related_items-e0133a5f" data-module="gem-toggle">
+        <ul class="gem-c-related-navigation__link-list govuk-list govuk-!-font-size-16" data-module="track-click">
+          <li><%= link_to 'Privacy', page_path(:privacy) %></li>
+        </ul>
+      </nav>
+    </aside>
+  </div>
+</div>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -25,8 +25,6 @@
 
     <p>The cookies aren’t used to identify you personally. You’ll normally see a message on the site before we store a cookie on your computer.</p>
 
-    <p>Find out more <a href="http://www.bbc.co.uk/webwise/guides/about-cookies" target="_blank" rel="external" data-outgoing-link=true data-outgoing-page="BBC Cookies Page">about cookies</a>.</p>
-
     <h2 class="govuk-heading-m">How cookies are used on this website</h2>
 
     <p>We use Google Analytics software to collect information about how you use this website. We do this to help make sure the site is meeting the needs of its users and to help us make improvements, for example improving the site structure and information architecture. We also send cross-domain tracking information to GOV.UK to help us understand and monitor performance data across multiple public services.</p>

--- a/app/views/shared/_cookie_banner.html.erb
+++ b/app/views/shared/_cookie_banner.html.erb
@@ -1,0 +1,32 @@
+<div id="global-cookie-message" class="gem-c-cookie-banner govuk-clearfix govuk-!-margin-top-4"
+     data-module="cookie-banner" role="region" aria-label="cookie banner"
+     data-nosnippet="" style="display: block;">
+  <div class="gem-c-cookie-banner__wrapper govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="gem-c-cookie-banner__message">
+          <h2 class="govuk-heading-m">Tell us whether you accept cookies</h2>
+          <p class="govuk-body">
+            We use
+            <a class="govuk-link" href="/cookies">cookies to collect information</a>
+            about how you use GOV.UK. We use this information to make the website work as
+            well as possible and improve government services.
+          </p>
+        </div>
+        <div class="gem-c-cookie-banner__buttons">
+          <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
+            <button class="gem-c-button govuk-button gem-c-button--inline" type="submit" data-module="track-click" data-accept-cookies="true" data-track-category="cookieBanner" data-track-action="Cookie banner accepted">Accept all cookies</button>
+          </div>
+          <div class="gem-c-cookie-banner__button gem-c-cookie-banner__button-settings govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
+            <a class="gem-c-button govuk-button gem-c-button--inline" role="button" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked" href="/cookie-preferences">Set cookie preferences</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="gem-c-cookie-banner__confirmation govuk-width-container" tabindex="-1">
+    <p class="gem-c-cookie-banner__confirmation-message">You’ve accepted all cookies. You can <a class="govuk-link" href="/cookie-preferences" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner settings clicked from confirmation">change your cookie settings</a> at any time.</p>
+    <button class="gem-c-cookie-banner__hide-button govuk-button gem-c-button--inline" data-hide-cookie-banner="true" data-module="track-click" data-track-category="cookieBanner" data-track-action="Hide cookie banner">Hide</button>
+  </div>
+</div>

--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -1,4 +1,4 @@
-<% if Rails.env == 'production' || Rails.env == 'staging'  %>
+<% if (Rails.env == 'production' || Rails.env == 'staging') && usage_cookies_allowed? %>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=<%= google_analytics_key %>"></script>
   <%= javascript_tag nonce: true, type: 'text/javascript' do %>

--- a/app/views/shared/_google_tag_body.html.erb
+++ b/app/views/shared/_google_tag_body.html.erb
@@ -1,6 +1,8 @@
-<!-- Google Tag Manager (noscript) -->
-<noscript>
-  <iframe src="https://www.googletagmanager.com/ns.html?id=<%= google_manager_key %>"
-          height="0" width="0" style="display:none;visibility:hidden"></iframe>
-</noscript>
-<!-- End Google Tag Manager (noscript) -->
+<% if usage_cookies_allowed? -%>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=<%= google_manager_key %>"
+            height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<%- end %>

--- a/app/views/shared/_google_tag_header.html.erb
+++ b/app/views/shared/_google_tag_header.html.erb
@@ -1,9 +1,11 @@
-<!-- Google Tag Manager -->
-<%= javascript_tag nonce: true do %>
-  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','<%= google_manager_key %>');
+<% if usage_cookies_allowed? -%>
+  <!-- Google Tag Manager -->
+  <%= javascript_tag nonce: true do %>
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','<%= google_manager_key %>');
+  <%- end %>
+  <!-- End Google Tag Manager -->
 <%- end %>
-<!-- End Google Tag Manager -->

--- a/app/views/shared/_govuk_footer.html.erb
+++ b/app/views/shared/_govuk_footer.html.erb
@@ -8,6 +8,9 @@
             <%= link_to t('accessibility.link'), page_path(:accessibility), class: 'govuk-footer__link' %>
           </li>
           <li class="govuk-footer__inline-list-item">
+            <%= link_to 'Cookies Preferences', page_path(:'cookie-preferences'), class: 'govuk-footer__link' %>
+          </li>
+          <li class="govuk-footer__inline-list-item">
             <%= link_to 'Cookies', page_path(:cookies), class: 'govuk-footer__link' %>
           </li>
           <li class="govuk-footer__inline-list-item">


### PR DESCRIPTION
# Required change

The page currently doesn't have a cookies banner, which makes it non-compliant with the GDPR directives.

Add a cookie banner and make sure the choices are respected by removing Google Analytics and Google Tag Manager when the usage cookies are rejected.

## Screenshots

### Cookie banner

<img width="680" alt="IS01-01-CookiesBanner" src="https://user-images.githubusercontent.com/2742327/88206225-d8c7bd80-cc45-11ea-8bf0-6498b158c6f2.png">

### All cookies accepted

<img width="668" alt="IS02-02-CookiesAccepted" src="https://user-images.githubusercontent.com/2742327/88206253-e11ff880-cc45-11ea-8e62-52f1e5c5a4c7.png">

### Cookies choice page

![cookies_setting](https://user-images.githubusercontent.com/2742327/96746899-8ff7e000-13bf-11eb-935c-45a46b911d08.jpg)

### Cookies choice saved

<img width="685" alt="IS02-04-CookiesChoiceSaved" src="https://user-images.githubusercontent.com/2742327/88206883-e467b400-cc46-11ea-8950-fe41c1f51bc0.png">

### Cookies guidance page

![cookies](https://user-images.githubusercontent.com/2742327/96746991-aef67200-13bf-11eb-8875-bda09450590f.jpg)
