### PR TITLE
Dev #595: Add label to search button

### DIFF
--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -19,6 +19,14 @@ $govuk-assets-path: '../../../node_modules/govuk-frontend/govuk/assets/';
 @import "npd-modal";
 @import "sticky";
 
+// visually hide text, let screen readers see it
+.screen-reader-text {
+  opacity: 0;
+  position: absolute;
+  top: -100px;
+  left: -100px;
+}
+
 // Custom styles to refactor somewhere
 .strong_link {
   font-weight: bold;

--- a/app/views/shared/_saved_data_panel.html.erb
+++ b/app/views/shared/_saved_data_panel.html.erb
@@ -1,4 +1,6 @@
 <a class="npd-saved-data" href="<%= saved_items_path %>">
   <%= t('saved_data.panel') %>
+  <span class="screen-reader-text"><%= t('saved_data.counter.contains') %></span>
   <span id="npd-counter" class="npd-counter">0</span>
+  <span class="screen-reader-text"><%= t('saved_data.counter.elements_saved') %></span>
 </a>

--- a/app/views/shared/_search_bar_small.html.erb
+++ b/app/views/shared/_search_bar_small.html.erb
@@ -1,5 +1,5 @@
 <form action="/search" method="get" class="govuk-form__inline" novalidate data-search-form=true>
   <input type="hidden" name="sort" id="search_sort" value="<%= params[:sort] || 'relevance' %>">
   <input class="govuk-input govuk-!-width-two-thirds govuk-input__search-bar" id="search" name="search" type="text" value="<%= params[:search] %>" placeholder="Search">
-  <button type="submit" class="govuk-button govuk-button-search govuk-button-search__header"></button>
+  <button type="submit" title="search" class="govuk-button govuk-button-search govuk-button-search__header"><span class="screen-reader-text">Search</span></button>
 </form>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,9 @@ en:
       title: Download Data Tables file
   saved_data:
     panel: My list
+    counter:
+      contains: contains
+      elements_saved: elements saved
     my_list:
       title: My list
       description: You can export this list of data elements into a .xlsx or .ods file.


### PR DESCRIPTION
Refers to ticket #595 .

Added a discernible text to that button.

An inspection of the whole application hasn't shown any other missing descriptive text for buttons.

The result can be tested using a screen reader once deployed on staging, or we can arrange a demo over a call.