### PR TITLE
Dev #597 remove duplicated ids

### DIFF
--- a/app/javascript/packs/saved_items_loader.js
+++ b/app/javascript/packs/saved_items_loader.js
@@ -49,9 +49,9 @@ $(document).ready(function() {
           element.addEventListener('click', removeDatasetFromMetadata)
         })
 
-        if(document.querySelector('#remove-all')) {
-          document.querySelector('#remove-all').addEventListener('click', removeAllFromMetadata)
-        }
+        $('.remove-all').each(function(idx, element) {
+          element.addEventListener('click', removeAllFromMetadata)
+        })
       }, 500)
     }
   })

--- a/app/views/concepts/_data_element_row.html.erb
+++ b/app/views/concepts/_data_element_row.html.erb
@@ -31,14 +31,14 @@
   <td data-label="Sensitivity" class="govuk-table__cell govuk-table__cell--numeric">
     <%= render 'shared/tooltip',
       label: t('concepts.show.sensitivity.label'),
-      id: 'sensitivity-tip-before',
+      id: "sensitivity-tip-before-#{data_element_row.id}",
       tooltip: t('concepts.show.sensitivity.tooltip') %>
     <%= data_element_row&.sensitivity %>
   </td>
   <td data-label="Identification risk" class="govuk-table__cell govuk-table__cell--numeric">
     <%= render 'shared/tooltip',
       label: t('concepts.show.identifiability.label'),
-      id: 'identifiability-tip-before',
+      id: "identifiability-tip-before-#{data_element_row.id}",
       tooltip: t('concepts.show.identifiability.tooltip') %>
     <%= data_element_row&.identifiability %>
   </td>

--- a/app/views/datasets/_data_element_row.html.erb
+++ b/app/views/datasets/_data_element_row.html.erb
@@ -28,14 +28,14 @@
   <td data-label="Sensitivity" class="govuk-table__cell govuk-table__cell--numeric">
     <%= render 'shared/tooltip',
       label: t('concepts.show.sensitivity.label'),
-      id: 'sensitivity-tip-before',
+      id: "sensitivity-tip-before-#{data_element_row.id}",
       tooltip: t('concepts.show.sensitivity.tooltip') %>
     <%= data_element_row&.sensitivity %>
   </td>
   <td data-label="Identification risk" class="govuk-table__cell govuk-table__cell--numeric">
     <%= render 'shared/tooltip',
       label: t('concepts.show.identifiability.label'),
-      id: 'identifiability-tip-before',
+      id: "identifiability-tip-before-#{data_element_row.id}",
       tooltip: t('concepts.show.identifiability.tooltip') %>
     <%= data_element_row&.identifiability %>
   </td>

--- a/app/views/saved_items/_element.html.erb
+++ b/app/views/saved_items/_element.html.erb
@@ -23,14 +23,14 @@
   <td data-label="Sensitivity" class="govuk-table__cell govuk-table__cell--numeric">
     <%= render 'shared/tooltip',
       label: t('concepts.show.sensitivity.label'),
-      id: 'sensitivity-tip-before',
+      id: "sensitivity-tip-before-#{data_element.id}",
       tooltip: t('concepts.show.sensitivity.tooltip') %>
     <%= data_element&.sensitivity %>
   </td>
   <td data-label="Identification risk" class="govuk-table__cell govuk-table__cell--numeric">
     <%= render 'shared/tooltip',
       label: t('concepts.show.identifiability.label'),
-      id: 'identifiability-tip-before',
+      id: "identifiability-tip-before-#{data_element.id}",
       tooltip: t('concepts.show.identifiability.tooltip') %>
     <%= data_element&.identifiability %>
   </td>

--- a/app/views/saved_items/_export_bar.html.erb
+++ b/app/views/saved_items/_export_bar.html.erb
@@ -1,12 +1,12 @@
-<div class="govuk-grid-row govuk-!-margin-top-4 govuk-!-margin-bottom-4" id="copyButton">
+<div class="govuk-grid-row govuk-!-margin-top-4 govuk-!-margin-bottom-4">
   <div class="govuk-grid-column-full govuk-text">
-    <button id="export-to-xlsx" name="format" value="xlsx" class="copy govuk-button govuk-!-margin-bottom-1" data-module="govuk-button">
+    <button name="format" value="xlsx" class="copy govuk-button govuk-!-margin-bottom-1 export-to-xlsx" data-module="govuk-button">
       Export to .xlsx file
     </button>
-    <button id="export-to-ods" name="format" value="ods" class="copy govuk-button govuk-!-margin-bottom-1" data-module="govuk-button">
+    <button name="format" value="ods" class="copy govuk-button govuk-!-margin-bottom-1 export-to-ods" data-module="govuk-button">
       Export to .ods file
     </button>
     <span class="govuk-!-margin-left-1">or</span>
-    <a href="" id="remove-all" class="govuk-!-font-size-16 govuk-!-padding-1 govuk-!-margin-bottom-1">Remove all</a>
+    <a href="" class="govuk-!-font-size-16 govuk-!-padding-1 govuk-!-margin-bottom-1 remove-all">Remove all</a>
   </div>
 </div>

--- a/app/views/saved_items/_saved_items.html.erb
+++ b/app/views/saved_items/_saved_items.html.erb
@@ -22,7 +22,7 @@
         <caption class="govuk-table__caption govuk-heading-m">
           <%= link_to dataset.tab_name.upcase, dataset_url(dataset) %>
         </caption>
-        <%= render partial: 'saved_items/saved_items_thead' %>
+        <%= render partial: 'saved_items/saved_items_thead', locals: { id: dataset.id } %>
         <tbody class="govuk-table__body">
           <%= render partial: 'saved_items/element', collection: group, as: :element, locals: { dataset: dataset } %>
           <tr class="govuk-table__row">

--- a/app/views/saved_items/_saved_items_thead.html.erb
+++ b/app/views/saved_items/_saved_items_thead.html.erb
@@ -1,5 +1,5 @@
 <thead class="govuk-table__head">
-  <tr class="govuk-table__row" id="data-elements-header">
+  <tr class="govuk-table__row" id="data-elements-header-<%= id %>">
     <th class="govuk-table__header" scope="col">
     </th>
     <th data-label="Name" class="govuk-table__header" scope="col">Name</th>
@@ -9,7 +9,7 @@
       <%= t('concepts.show.sensitivity.label') %>
       <%= render 'shared/tooltip',
         label: t('concepts.show.sensitivity.label'),
-        id: 'sensitivity-tip',
+        id: "sensitivity-tip-#{id}",
         tooltip: t('concepts.show.sensitivity.tooltip'),
         position: 'bottom-left' %>
     </th>
@@ -17,7 +17,7 @@
       <%= t('concepts.show.identifiability.label') %>
       <%= render 'shared/tooltip',
         label: t('concepts.show.identifiability.label'),
-        id: 'identifiability-tip',
+        id: "identifiability-tip-#{id}",
         tooltip: t('concepts.show.identifiability.tooltip'),
         position: 'bottom-right' %>
     </th>


### PR DESCRIPTION
Related to issue #597 

After the initial investigation, a few duplicated IDs were found, mostly related to automatically generated data on the page.

The duplicated IDs were either removed (when no longer necessary) or made ID unique.

This PR can be tested after deploying in staging (potentially using the https://chrome.google.com/webstore/detail/dup-id-scans-html-for-dup/nggpgolddgjmkjioagggmnmddbgedice chrome extension) or during a call.