### PR TITLE
Dev #604 - fix "remove" link

### DIFF
--- a/app/views/saved_items/_element.html.erb
+++ b/app/views/saved_items/_element.html.erb
@@ -2,9 +2,13 @@
 
 <tr class="govuk-table__row" id="<%= data_element.id %>_data">
   <td class="govuk-table__header govuk-table__cell--small" scope="col">
-    <a href="remove-<%= data_element.id %>" class="item-remove" id="<%= data_element.id %>"
+    <a href="remove-<%= data_element.id %>" class="item-remove govuk-body-s" id="<%= data_element.id %>"
         data-dataset-id="<%= dataset.id %>">
-      remove
+      Remove
+      <span class="screen-reader-text">
+        <%= data_element.title(dataset) %>
+        <%= t('saved_data.my_list.from_my_list') %>
+      </span>
     </a>
   </td>
   <th data-label="Name" class="govuk-table__header govuk-table__cell--break" scope="row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,7 @@ en:
       link: applying for access
       no_elements: You currently have no elements saved in your list
       additional_notes: Additional notes
+      from_my_list: from my list
     button: Save to my list
     instructions: You can use the checkboxes below to add data elements to your list
     copy_title: Saved in this session


### PR DESCRIPTION
# Changes to data element 'remove' link on 'My list' pages

Refers to https://github.com/DFE-Digital/npd-find-and-explore/issues/604

## Change 1:

An accessibility audit of the F&E tool recommended that the 'remove' link that is provided for each individual data element on the 'My list' page is given a better contextual description for accessibility software.

For each data element 'remove' link, the contextual description is now in the format 'Remove [data element name] from my list'

No screenshot available for this, testable using the native Windows screen reader.

## Change 2:

Currently the 'remove' link for each data element on 'My list' is in the same format, i.e. bold and underlined, as the data element name. To emphasise that the 'remove link is not part of the data element name, we should

Ensure 'remove' is in normal, not bold text
Capitalise the 'r', i.e. 'Remove'

### Screenshot

<img width="1077" alt="Screen Shot 2020-09-10 at 14 14 34" src="https://user-images.githubusercontent.com/2742327/92734155-2e7c3480-f370-11ea-8692-92fba971a816.png">
