### PR TITLE
Dev #509 - change copy

### DIFF
--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -35,7 +35,6 @@
 
     <ul class="govuk-list govuk-list--bullet">
       <li>some data is presented in tables which can be problematic for smaller devices and screen readers</li>
-      <li>we don't currently have filters on our search. We're working on including filters as part of our next release which should help manage the amount of data a search could return</li>
       <li>if you download the data tables spreadsheet you might have problems accessing the information as it's not accessible</li>
     </ul>
 
@@ -60,7 +59,7 @@
     <p>This service is fully compliant with the <a rel="external" href="https://www.w3.org/TR/WCAG21/" data-outgoing-link=true data-outgoing-page="W3">Web Content Accessibility Guidelines version 2.1 AA standard</a>.</p>
 
     <h2 class="govuk-heading-m">How we tested this service</h2>
-    <p>The service was last tested on 01 September 2019 and was checked for compliance with WCAG 2.1 AA. The test was carried out by our internal Accessibility Advisor.</p>
+    <p>The service was last tested on 14 September 2020 and was checked for compliance with WCAG 2.1 AA. The test was carried out by our internal Accessibility Advisor.</p>
 
     <h2 class="govuk-heading-m">What we’re doing to improve accessibility</h2>
     <p>We will be continuously testing to ensure any new features meet accessibility guidelines.</p>


### PR DESCRIPTION
# Update F&E accessibility statement

An accessibility assurance re-test of Find & Explore was carried out on 14/09/2020. The assessment found no issues and the report concluded that the service meets the WCAG 2.1 AA level of compliance.

## Changes

Changes to the F&E accessibility statement (https://find-npd-data.education.gov.uk/accessibility):

* Removed the statement 'we don't currently have filters on our search. We're working on including filters as part of our next release which should help manage the amount of data a search could return'.
* Under 'How we tested this service', date of the test changed from ‘01 September 2019’ to ‘14 September 2020’.

## Screenshots

![Accessibility](https://user-images.githubusercontent.com/2742327/93203181-de281c80-f74b-11ea-9185-0f985a7a57d3.jpg)
