### PR TITLE
Dev #620: Amend 'Accessibility' link footer and page title

### DIFF
--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -2,10 +2,10 @@
   <%= javascript_pack_tag 'navigation' %>
 <%- end %>
 
-<% @title = 'Accessibility' %>
+<% @title = t('accessibility.title') %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">
       <%= @title %>
     </h1>
@@ -14,7 +14,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m">Accessibility for Find and Explore data in the National Pupil Database</h2>
     <p>This service is part of the wider GOV.UK website. There’s a separate accessibility statement for the main GOV.UK website.</p>
     <p>This page only contains information about the Find and Explore data in the National Pupil Database service, available at
       <a href="https://find-npd-data.education.gov.uk">https://find-npd-data.education.gov.uk</a>.</p>

--- a/app/views/shared/_govuk_footer.html.erb
+++ b/app/views/shared/_govuk_footer.html.erb
@@ -5,7 +5,7 @@
         <h2 class="govuk-visually-hidden">Support links</h2>
         <ul class="govuk-footer__inline-list">
           <li class="govuk-footer__inline-list-item">
-            <%= link_to 'Accessibility', page_path(:accessibility), class: 'govuk-footer__link' %>
+            <%= link_to t('accessibility.link'), page_path(:accessibility), class: 'govuk-footer__link' %>
           </li>
           <li class="govuk-footer__inline-list-item">
             <%= link_to 'Cookies', page_path(:cookies), class: 'govuk-footer__link' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,7 +97,9 @@ en:
     instructions: You can use the checkboxes below to add data elements to your list
     copy_title: Saved in this session
     copy_instructions: This list of data elements will disappear when you clear your cookies for this site or by selecting 'Remove all' below.
-
+  accessibility:
+    title: Accessibility statement for Find and Explore Data in the National Pupil Database
+    link: Accessibility statement
   views:
     pagination:
       first: "&laquo; First"


### PR DESCRIPTION
# Amend 'Accessibility' link footer and page title

## Detail of work

GDS guidance states that links to Accessibility statements on GOV.UK should be called 'Accessibility statement' and that the Accessibility statement page should have the title 'Accessibility statement for [website name]'.

### Work to be done:

* Change the link to the Accessibility page to 'Accessibility statement'
* Change the title of the Accessibility page to 'Accessibility statement for Find and Explore Data in the National Pupil Database'
* Remove the sub-heading in the Accessibility page, since now it is exactly the same as the title

## Screenshots

### Footer Link

<img width="800" alt="Screen Shot 2020-09-29 at 17 17 14" src="https://user-images.githubusercontent.com/2742327/94585894-84117600-0278-11eb-8e29-b525e80ab795.png">

### Accessibility page

<img width="813" alt="Screen Shot 2020-09-29 at 17 17 02" src="https://user-images.githubusercontent.com/2742327/94585926-8f64a180-0278-11eb-8d92-5932c2d8a846.png">

