### PR TITLE
Dev #617 - Changes to layout of Data Elements tables

### DIFF
--- a/app/javascript/src/_checkboxes.scss
+++ b/app/javascript/src/_checkboxes.scss
@@ -2,7 +2,7 @@
   .govuk-checkboxes__item {
     margin-bottom: 0;
     min-height: 20px;
-    padding: 0 0 0 20px;
+    padding: 0;
   }
 
   .govuk-checkboxes__input {

--- a/app/javascript/src/_checkboxes.scss
+++ b/app/javascript/src/_checkboxes.scss
@@ -1,16 +1,8 @@
-.govuk-checkboxes--small .govuk-checkboxes__item {
-  padding-left: 0;
-}
-
-.govuk-checkboxes-small {
+.govuk-checkboxes--small {
   .govuk-checkboxes__item {
     margin-bottom: 0;
-    min-height: 40px;
+    min-height: 20px;
     padding: 0 0 0 20px;
-  }
-
-  .govuk-checkboxes__label {
-    padding: 0 15px 5px;
   }
 
   .govuk-checkboxes__input {
@@ -22,7 +14,7 @@
   {
     height: 20px;
     left: 0;
-    top: 0;
+    top: 1px;
     width: 20px;
   }
 
@@ -31,7 +23,7 @@
     border-width: 0 0 3px 3px;
     height: 4px;
     left: 4px;
-    top: 5px;
+    top: 0;
     width: 9px;
   }
 

--- a/app/javascript/src/_checkboxes.scss
+++ b/app/javascript/src/_checkboxes.scss
@@ -1,3 +1,7 @@
+.govuk-checkboxes--small .govuk-checkboxes__item {
+  padding-left: 0;
+}
+
 .govuk-checkboxes-small {
   .govuk-checkboxes__item {
     margin-bottom: 0;

--- a/app/javascript/src/_checkboxes.scss
+++ b/app/javascript/src/_checkboxes.scss
@@ -5,11 +5,6 @@
     padding: 0;
   }
 
-  .govuk-checkboxes__input {
-    height: 20px;
-    width: 20px;
-  }
-
   .govuk-checkboxes__input + .govuk-checkboxes__label::before
   {
     height: 20px;
@@ -23,7 +18,7 @@
     border-width: 0 0 3px 3px;
     height: 4px;
     left: 4px;
-    top: 0;
+    top: 5px;
     width: 9px;
   }
 

--- a/app/javascript/src/_tables.scss
+++ b/app/javascript/src/_tables.scss
@@ -26,6 +26,11 @@ table td .tooltip {
   word-break: break-all;
 }
 
+.govuk-table__cell--no-break {
+  word-break: keep-all;
+  overflow-wrap: normal;
+}
+
 @include govuk-media-query($until: tablet) {
   table thead {
     border: 0;
@@ -59,11 +64,6 @@ table td .tooltip {
     display: inline-block;
     left: -50%;
     position: relative;
-
-    .help {
-      font-weight: bold;
-      padding: 3px 12px 0;
-    }
   }
 
   table td .tooltip, h2 .tooltip {

--- a/app/javascript/src/_tooltip.scss
+++ b/app/javascript/src/_tooltip.scss
@@ -5,9 +5,9 @@
     background-color: $govuk-brand-colour;
     border-radius: 20px;
     color: govuk-colour('white');
-    font-size: 19px;
-    margin-left: 8px;
-    padding: 3px 12px 0;
+    font-size: 16px;
+    margin-left: 2px;
+    padding: 1px 8px 0;
     position: relative;
     text-decoration: none;
 

--- a/app/javascript/src/_tooltip.scss
+++ b/app/javascript/src/_tooltip.scss
@@ -1,5 +1,7 @@
 .tooltip {
   position: relative;
+  display: block;
+  text-align: center;
 
   .help {
     background-color: $govuk-brand-colour;

--- a/app/javascript/src/_tooltip.scss
+++ b/app/javascript/src/_tooltip.scss
@@ -5,9 +5,9 @@
     background-color: $govuk-brand-colour;
     border-radius: 20px;
     color: govuk-colour('white');
-    font-size: 16px;
+    font-size: 13px;
     margin-left: 2px;
-    padding: 1px 8px 0;
+    padding: 1px 7px 0;
     position: relative;
     text-decoration: none;
 

--- a/app/views/concepts/_data_element_row.html.erb
+++ b/app/views/concepts/_data_element_row.html.erb
@@ -42,7 +42,7 @@
       tooltip: t('concepts.show.identifiability.tooltip') %>
     <%= data_element_row&.identifiability %>
   </td>
-  <td data-label="Value" class="govuk-table__cell govuk-table__cell--numeric govuk-table__cell--break">
+  <td data-label="Value" class="govuk-table__cell govuk-table__cell--numeric govuk-table__cell--no-break">
     <%- if /\n/ =~ data_element_row.values %>
       <div class="overlay-parent">
         <a href="#" class="codeset" aria-describedby="codeset-<%= data_element_row.title.downcase %>" title="Codeset for <%= data_element_row.title %>">

--- a/app/views/concepts/_data_element_row.html.erb
+++ b/app/views/concepts/_data_element_row.html.erb
@@ -1,9 +1,6 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__header" scope="col">
     <div class="govuk-checkboxes govuk-checkboxes--small">
-      <a href="" class="show-modal hidden">
-        <strong class="saved govuk-tag govuk-!-font-size-14">saved</strong>
-      </a>
       <div class="govuk-checkboxes__item">
         <%= check_box_tag 'data_element[]', data_element_row.title, false,
           id: "data-element-#{data_element_row.id}", class: %w[govuk-checkboxes__input basket-checkbox],

--- a/app/views/datasets/_data_element_row.html.erb
+++ b/app/views/datasets/_data_element_row.html.erb
@@ -39,7 +39,7 @@
       tooltip: t('concepts.show.identifiability.tooltip') %>
     <%= data_element_row&.identifiability %>
   </td>
-  <td data-label="Value" class="govuk-table__cell govuk-table__cell--numeric govuk-table__cell--break">
+  <td data-label="Value" class="govuk-table__cell govuk-table__cell--numeric govuk-table__cell--no-break">
     <%- if /\n/ =~ data_element_row.values %>
       <div class="overlay-parent">
         <a href="#" class="codeset" aria-describedby="codeset-<%= data_element_row.title.downcase %>" title="Codeset for <%= data_element_row.title(@dataset) %>">

--- a/app/views/saved_items/_element.html.erb
+++ b/app/views/saved_items/_element.html.erb
@@ -38,7 +38,7 @@
       tooltip: t('concepts.show.identifiability.tooltip') %>
     <%= data_element&.identifiability %>
   </td>
-  <td data-label="Value" class="govuk-table__cell govuk-table__cell--numeric govuk-table__cell--break">
+  <td data-label="Value" class="govuk-table__cell govuk-table__cell--numeric govuk-table__cell--no-break">
     <%- if /\n/ =~ data_element.values %>
       <div class="overlay-parent">
         <a href="#" class="codeset" aria-describedby="codeset-<%= data_element.title.downcase %>" title="Codeset for <%= data_element.title(dataset) %>">


### PR DESCRIPTION
# Changes to layout of Data Elements tables

## Changes

1. Column header text is top aligned.
2. The 'i' icons is reduced in size and appears centrally under the column header text 'Sensitivity' and 'Identifiability'.
3. The 'Name' column is to the left, so there is less white space between it and the checkboxes.
4. The 'Values' column is able to accommodate the word 'Alphanumeric' without it wrapping to the next line.
5. The checkboxes is top aligned, so the top of the checkboxes are in line with the top of the text in each column.

## Screenshot

<img width="918" alt="Screen Shot 2020-09-30 at 14 09 40" src="https://user-images.githubusercontent.com/2742327/94689336-ab268100-0326-11eb-8cfd-082f1bb3b7c9.png">
