### PR TITLE
Dev #618 - Reduce white space on My list page

### DIFF
--- a/app/controllers/saved_items_controller.rb
+++ b/app/controllers/saved_items_controller.rb
@@ -16,7 +16,7 @@ class SavedItemsController < ApplicationController
   end
 
   def saved_items
-    render partial: 'saved_items', layout: false, locals: { grouped_elements: grouped_elements, range_errors: [] }
+    render partial: 'saved_items', layout: false, locals: { grouped_elements: grouped_elements }
   end
 
   def export_to_csv

--- a/app/views/saved_items/_saved_items.html.erb
+++ b/app/views/saved_items/_saved_items.html.erb
@@ -1,20 +1,5 @@
 <%- if grouped_elements.any? %>
   <%= form_with url: export_to_csv_saved_items_path, remote: true do -%>
-    <% if range_errors.any? -%>
-      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
-          Can't export the information
-        </h2>
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <% range_errors.each do |error| -%>
-              <li><a href="#"><%= error %></a></li>
-            <%- end %>
-          </ul>
-        </div>
-      </div>
-    <%- end %>
-
     <%= render partial: 'export_bar' %>
 
     <%- grouped_elements.each do |dataset, group| %>

--- a/app/views/saved_items/index.html.erb
+++ b/app/views/saved_items/index.html.erb
@@ -8,7 +8,7 @@
     <div class="saved_items_table govuk-text">
       <% if defined? grouped_elements -%>
         <%= render partial: 'saved_items',
-          locals: { grouped_elements: grouped_elements, range_errors: ((defined? range_errors) ? range_errors : []) } %>
+          locals: { grouped_elements: grouped_elements } %>
       <%- else -%>
         <%= render partial: 'saved_items_loading' %>
       <%- end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,16 +3,21 @@
     <h1 class="govuk-heading-<%= size %> govuk-!-margin-bottom-0">
       <%= @title %>
     </h1>
+    <% if saved_items_page? -%>
+      <p class="description govuk-!-margin-top-4"><%= @description&.html_safe %></p>
+    <%- end %>
   </div>
   <div class="govuk-grid-column-one-third">
     <%= render partial: 'shared/saved_data_panel' unless saved_items_page? %>
-  </div>
-</div>
-<div class="govuk-grid-row govuk-!-margin-top-5">
-  <div class="govuk-grid-column-two-thirds">
-    <p class="description"><%= @description&.html_safe %></p>
-  </div>
-  <div class="govuk-grid-column-one-third">
     <%= render partial: 'shared/transient_data_warning' if saved_items_page? %>
   </div>
 </div>
+<% unless saved_items_page? -%>
+  <div class="govuk-grid-row govuk-!-margin-top-5">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="description"><%= @description&.html_safe %></p>
+    </div>
+    <div class="govuk-grid-column-one-third">
+    </div>
+  </div>
+<%- end %>


### PR DESCRIPTION
# Reduce white space on My list page

## Detail of work

The 'My list' header has been moved downwards, so that the top of the 'My list' text is aligned with the top of the blue box that contains the 'Save in this session' text.

## Screenshot

<img width="1006" alt="Screen Shot 2020-09-30 at 14 33 44" src="https://user-images.githubusercontent.com/2742327/94694636-f6dc2900-032c-11eb-891f-573f47e203ed.png">
