### PR TITLE
Dev #628 - Bug - Admin Area: Update 'Change password' tooltip

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -33,7 +33,7 @@
         <div class="govuk-hint">(leave blank if you don't want to change it)</div>
         <%= f.password_field :password, autocomplete: 'new-password', class: 'govuk-input' %>
         <% if @minimum_password_length %>
-          <div class="govuk-hint"><%= @minimum_password_length %> characters minimum</div>
+          <div class="govuk-hint"><%= t('devise.passwords.format', length: @minimum_password_length) %></div>
         <% end %>
         <% if f.object.errors[:password].present? %>
           <span class="govuk-error-message">

--- a/app/views/fields/password/_form.html.erb
+++ b/app/views/fields/password/_form.html.erb
@@ -1,0 +1,23 @@
+<%#
+  # Password Form Partial
+  # This partial renders an input element for a password attribute.
+  # By default, the input is a password field.
+  # ## Local variables:
+  # - `f`:
+  #   A Rails form generator, used to help create the appropriate input fields.
+  #   - `field`:
+  #     An instance of [Administrate::Field::Password][1].
+  #       A wrapper around the Password.
+  #       [1]:
+  #       http://www.rubydoc.info/gems/administrate/Administrate/Field/Password
+  #       %>
+
+<div class="field-unit__label">
+  <%= f.label field.attribute %>
+</div>
+<div class="field-unit__field">
+  <%= f.password_field field.attribute, value: field.data %>
+  <% if field.attribute == :password -%>
+    <div class="govuk-hint"><%= t('devise.passwords.format', length: 8) %></div>
+  <%- end %>
+</div>.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -198,7 +198,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -37,6 +37,7 @@ en:
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."
       updated_not_active: "Your password has been changed successfully."
+      format: "Your password should be %{length} characters minimum and contain at least one uppercase letter, one lowercase letter, one number and one special character."
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."


### PR DESCRIPTION
# Bug - Admin Area: Update 'Change password' tooltip

## Content

In the admin area, the password format tooltip now reads:

> Your password should be 8 characters minimum and contain at least one uppercase letter, one lowercase letter, one number and one special character.

This both in the "edit admin user" (where the tooltip was wrong) and in the "new admin user" page (where the tooltip was missing entirely).

## Screenshots

### Edit Admin User

<img width="989" alt="Screen Shot 2020-10-14 at 11 57 37" src="https://user-images.githubusercontent.com/2742327/95980061-8517db00-0e14-11eb-8068-ee20d7adf8ec.png">

### New Admin User

<img width="983" alt="Screen Shot 2020-10-14 at 11 49 31" src="https://user-images.githubusercontent.com/2742327/95980094-8fd27000-0e14-11eb-9493-8fbbc0e1a5c6.png">
