### PR TITLE
Dev #629 - Bug - Admin Area: Can't assign new data elements to concepts

### DIFF
--- a/app/dashboards/data_element_dashboard.rb
+++ b/app/dashboards/data_element_dashboard.rb
@@ -94,6 +94,6 @@ class DataElementDashboard < Administrate::BaseDashboard
   # across all pages of the admin dashboard.
   #
   def display_resource(data_element)
-    "#{data_element.source_table_name}.#{data_element.source_attribute_name}"
+    [data_element.dataset, data_element.npd_alias].compact.join('.')
   end
 end


### PR DESCRIPTION
# Bug - Admin Area: Can't assign new data elements to concepts

## Development

When editing a concept to add new data elements, all the available data elements should be searchable by dataset and NPD Alias from the search box.

## Screenshot

<img width="999" alt="Screen Shot 2020-10-14 at 13 45 46" src="https://user-images.githubusercontent.com/2742327/95990649-b350e700-0e23-11eb-80d0-45e233bc5302.png">
