### PR TITLE
Dev #631 - Bug - Admin Area: Can't add or move subcategories using the 'Sort Categories' tool

### DIFF
--- a/app/helpers/nestable_helper.rb
+++ b/app/helpers/nestable_helper.rb
@@ -13,7 +13,8 @@ module NestableHelper
           link_to object_label(tree_node), edit_admin_category_path(tree_node.id)
         end
 
-        output += content_tag(:ol, nested_tree_nodes(sub_tree_nodes), class: 'list-group nested-sortable dd-list') if sub_tree_nodes&.any?
+        content = sub_tree_nodes&.any? ? nested_tree_nodes(sub_tree_nodes) : ''
+        output += content_tag(:ol, content, class: 'list-group nested-sortable dd-list')
         output
       end
     end


### PR DESCRIPTION
# Bug - Admin Area: Can't add or move subcategories using the 'Sort Categories' tool

## Problem

When signed in as an admin user, the 'Sort Categories' tool doesn't let you add a subcategory to a category that doesn't already have any subcategories.

## Development

The 'Sort Categories' tool will now let you add a subcategory to a category that doesn't already have any subcategories.

## Screenshots

### Initial tree with "No Category" having no sub-categories

<img width="1080" alt="Screen Shot 2020-10-14 at 16 41 14" src="https://user-images.githubusercontent.com/2742327/96012689-46961680-0e3c-11eb-952e-0bf57a6cacd1.png">

### Moving the "CIN child details" category under "No Category" (which was previously empty)

<img width="1075" alt="Screen Shot 2020-10-14 at 16 41 22" src="https://user-images.githubusercontent.com/2742327/96012715-4eee5180-0e3c-11eb-9fb4-ff788c3f24bb.png">


