### PR TITLE
Dev #630 - Admin area: Add total number of items in list pages

### DIFF
--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -246,7 +246,7 @@ $govuk-assets-path: '../../../node_modules/govuk-frontend/govuk/assets/';
   }
 }
 
-.right {
+.right, .float-right {
   float: right;
 }
 

--- a/app/views/admin/application/_collection.html.erb
+++ b/app/views/admin/application/_collection.html.erb
@@ -1,0 +1,97 @@
+<%#
+# Collection
+
+This partial is used on the `index` and `show` pages
+to display a collection of resources in an HTML table.
+
+## Local variables:
+
+- `collection_presenter`:
+  An instance of [Administrate::Page::Collection][1].
+  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
+  the columns displayed in the table
+- `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<table aria-labelledby="<%= table_title %>">
+  <thead>
+    <tr>
+      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th class="cell-label
+        cell-label--<%= attr_type.html_class %>
+        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>"
+        scope="col"
+        role="columnheader"
+        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
+        <%= link_to(sanitized_order_params(page, collection_field_name).merge(
+          collection_presenter.order_params_for(attr_name, key: collection_field_name)
+        )) do %>
+        <%= t(
+          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+          default: attr_name.to_s,
+        ).titleize %>
+            <% if collection_presenter.ordered_by?(attr_name) %>
+              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+                <svg aria-hidden="true">
+                  <use xlink:href="#icon-up-caret" />
+                </svg>
+              </span>
+            <% end %>
+          <% end %>
+        </th>
+      <% end %>
+      <% [valid_action?(:edit, collection_presenter.resource_name),
+          valid_action?(:destroy, collection_presenter.resource_name)].count(true).times do %>
+        <th scope="col"></th>
+      <% end %>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr class="js-table-row"
+          <% if show_action? :show, resource %>
+            <%= %(tabindex=0 role=link data-url=#{polymorphic_path([namespace, resource])}) %>
+          <% end %>
+          >
+        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
+            <% if show_action? :show, resource -%>
+              <a href="<%= polymorphic_path([namespace, resource]) -%>"
+                 tabindex="-1"
+                 class="action-show"
+                 >
+                <%= render_field attribute %>
+              </a>
+            <% else %>
+              <%= render_field attribute %>
+            <% end -%>
+          </td>
+        <% end %>
+
+        <% if valid_action? :edit, collection_presenter.resource_name %>
+          <td><%= link_to(
+            t("administrate.actions.edit"),
+            [:edit, namespace, resource],
+            class: "action-edit",
+          ) if show_action? :edit, resource%></td>
+        <% end %>
+
+        <% if valid_action? :destroy, collection_presenter.resource_name %>
+          <td><%= link_to(
+            t("administrate.actions.destroy"),
+            [namespace, resource],
+            class: "text-color-red",
+            method: :delete,
+            data: { confirm: t("administrate.actions.confirm") }
+          ) if show_action? :destroy, resource %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/application/index.html.erb
+++ b/app/views/admin/application/index.html.erb
@@ -1,0 +1,74 @@
+<%#
+# Index
+
+This view is the template for the index page.
+It is responsible for rendering the search bar, header and pagination.
+It renders the `_table` partial to display details about the resources.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Collection][1].
+  Contains helper methods to help display a table,
+  and knows which attributes should be displayed in the resource's table.
+- `resources`:
+  An instance of `ActiveRecord::Relation` containing the resources
+  that match the user's search criteria.
+  By default, these resources are passed to the table partial to be displayed.
+- `search_term`:
+  A string containing the term the user has searched for, if any.
+- `show_search_bar`:
+  A boolean that determines if the search bar should be shown.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<% content_for(:title) do %>
+  <%= display_resource_name(page.resource_name) %>
+<% end %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <% if show_search_bar %>
+    <%= render(
+      "search",
+      search_term: search_term,
+      resource_name: display_resource_name(page.resource_name)
+    ) %>
+  <% end %>
+
+  <div>
+    <%= link_to(
+      t(
+        "administrate.actions.new_resource",
+        name: page.resource_name.titleize.downcase
+      ),
+      [:new, namespace, page.resource_path],
+      class: "button",
+    ) if valid_action?(:new) && show_action?(:new, new_resource) %>
+  </div>
+</header>
+
+<section class="main-content__body main-content__body--flush">
+  <%= paginate resources %>
+  <span class="govuk-body govuk-!-font-size-14 float-right govuk-!-margin-top-5">
+    <%= page_entries_info resources %>
+  </span>
+
+  <%= render(
+    "collection",
+    collection_presenter: page,
+    collection_field_name: resource_name,
+    page: page,
+    resources: resources,
+    table_title: "page-title"
+  ) %>
+
+  <%= paginate resources %>
+  <span class="govuk-body govuk-!-font-size-14 float-right govuk-!-margin-top-5">
+    <%= page_entries_info resources %>
+  </span>
+</section>

--- a/app/views/admin/categories/childless.html.erb
+++ b/app/views/admin/categories/childless.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) do %>
-  <%= display_resource_name(page.resource_name) %>
+  Childless Categories
 <% end %>
 
 <header class="main-content__header" role="banner">
@@ -9,6 +9,11 @@
 </header>
 
 <section class="main-content__body main-content__body--flush">
+  <%= paginate resources %>
+  <span class="govuk-body govuk-!-font-size-14 float-right govuk-!-margin-top-5">
+    <%= page_entries_info resources %>
+  </span>
+
   <%= render(
     "collection",
     collection_presenter: page,
@@ -18,5 +23,8 @@
     table_title: "page-title"
   ) %>
 
-<%= paginate resources %>
+  <%= paginate resources %>
+  <span class="govuk-body govuk-!-font-size-14 float-right govuk-!-margin-top-5">
+    <%= page_entries_info resources %>
+  </span>
 </section>

--- a/app/views/admin/concepts/childless.html.erb
+++ b/app/views/admin/concepts/childless.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) do %>
-  <%= display_resource_name(page.resource_name) %>
+  Childless Concepts
 <% end %>
 
 <header class="main-content__header" role="banner">
@@ -9,6 +9,11 @@
 </header>
 
 <section class="main-content__body main-content__body--flush">
+  <%= paginate resources %>
+  <span class="govuk-body govuk-!-font-size-14 float-right govuk-!-margin-top-5">
+    <%= page_entries_info resources %>
+  </span>
+
   <%= render(
     "collection",
     collection_presenter: page,
@@ -18,5 +23,8 @@
     table_title: "page-title"
   ) %>
 
-<%= paginate resources %>
+  <%= paginate resources %>
+  <span class="govuk-body govuk-!-font-size-14 float-right govuk-!-margin-top-5">
+    <%= page_entries_info resources %>
+  </span>
 </section>

--- a/app/views/admin/data_elements/orphaned.html.erb
+++ b/app/views/admin/data_elements/orphaned.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) do %>
-  <%= display_resource_name(page.resource_name) %>
+  Orphaned Data Elements
 <% end %>
 
 <header class="main-content__header" role="banner">
@@ -9,6 +9,11 @@
 </header>
 
 <section class="main-content__body main-content__body--flush">
+  <%= paginate resources %>
+  <span class="govuk-body govuk-!-font-size-14 float-right govuk-!-margin-top-5">
+    <%= page_entries_info resources %>
+  </span>
+
   <%= render(
     "collection",
     collection_presenter: page,
@@ -18,6 +23,9 @@
     table_title: "page-title"
   ) %>
 
-<%= paginate resources %>
+  <%= paginate resources %>
+  <span class="govuk-body govuk-!-font-size-14 float-right govuk-!-margin-top-5">
+    <%= page_entries_info resources %>
+  </span>
 </section>
 


### PR DESCRIPTION
# Admin area: Add total number of items in list pages

## Description

As an F&E administrator
I want the admin tool to show me how many categories, concepts and data elements are in its paginated lists
So that I can more easily check the outcome of a Data Tables import

## Screenshots

### Categories

![admin_categories_pagination](https://user-images.githubusercontent.com/2742327/96099880-a556a100-0ecb-11eb-8157-ac04ceed418c.jpg)

### Childess Categories

<img width="995" alt="Screen Shot 2020-10-15 at 10 16 09" src="https://user-images.githubusercontent.com/2742327/96103373-8a862b80-0ecf-11eb-8207-8493e3a028e5.png">

### Concepts

![admin_concepts_pagination](https://user-images.githubusercontent.com/2742327/96103888-1d26ca80-0ed0-11eb-8f72-d8c662d6872b.jpg)

### Childless Concepts

<img width="993" alt="Screen Shot 2020-10-15 at 10 20 40" src="https://user-images.githubusercontent.com/2742327/96103949-2d3eaa00-0ed0-11eb-80b2-5e8987aa2de5.png">

### Data Elements

![admin_data_elements_pagination](https://user-images.githubusercontent.com/2742327/96104052-45aec480-0ed0-11eb-92ce-323e1b903e14.jpg)

### Orphaned Data Elements

![admin_orphaned_data_elements_pagination](https://user-images.githubusercontent.com/2742327/96104126-5cedb200-0ed0-11eb-8d99-9e7122d584ad.jpg)

### Datasets

![admin_datasets_pagination](https://user-images.githubusercontent.com/2742327/96104699-1056a680-0ed1-11eb-9d04-32a923cb9cbe.jpg)



