### PR TITLE
Dev #640 - Limit 'Values' column to 30 characters

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,6 +42,14 @@ module ApplicationHelper
     result.description || result.placeholder_description
   end
 
+  def decompose_row_values(values)
+    if values && (/\n/ =~ values || values.length > 30)
+      { label: 'Allowed Values', extended: values.split("\n") }
+    else
+      { label: values }
+    end
+  end
+
   def sort_options
     [
       %w[Relevance relevance],

--- a/app/views/concepts/_data_element_row.html.erb
+++ b/app/views/concepts/_data_element_row.html.erb
@@ -40,25 +40,11 @@
     <%= data_element_row&.identifiability %>
   </td>
   <td data-label="Value" class="govuk-table__cell govuk-table__cell--numeric govuk-table__cell--no-break">
-    <%- if /\n/ =~ data_element_row.values %>
-      <div class="overlay-parent">
-        <a href="#" class="codeset" aria-describedby="codeset-<%= data_element_row.title.downcase %>" title="Codeset for <%= data_element_row.title %>">
-          Codeset<span class="codeset-specification">for <%= data_element_row.title %></span>
-        </a>
-        <div class="overlay" role="overlay" id="codeset-<%= data_element_row.title.downcase %>">
-          <div class="overlay-content">
-            <span class="overlay-header">
-              <span>Codeset values for <%= data_element_row.title %></span>
-              <a href="#" class="overlay-close">X</a>
-            </span>
-            <%- data_element_row.values.split("\n") do |line| %>
-              <span><%= line %></span><br />
-            <%- end %>
-          </div>
-        </div>
-      </div>
+    <% row_values = decompose_row_values(data_element_row.values) %>
+    <%- if row_values.dig(:extended).present? %>
+      <%= render 'shared/values_overlay', row: data_element_row, values: row_values %>
     <%- else %>
-      <%= data_element_row.values %>
+      <%= row_values.dig(:label) %>
     <%- end %>
   </td>
 </tr>

--- a/app/views/datasets/_data_element_row.html.erb
+++ b/app/views/datasets/_data_element_row.html.erb
@@ -40,25 +40,11 @@
     <%= data_element_row&.identifiability %>
   </td>
   <td data-label="Value" class="govuk-table__cell govuk-table__cell--numeric govuk-table__cell--no-break">
-    <%- if /\n/ =~ data_element_row.values %>
-      <div class="overlay-parent">
-        <a href="#" class="codeset" aria-describedby="codeset-<%= data_element_row.title.downcase %>" title="Codeset for <%= data_element_row.title(@dataset) %>">
-          Codeset<span class="codeset-specification">for <%= data_element_row.title(@dataset) %></span>
-        </a>
-        <div class="overlay" role="overlay" id="codeset-<%= data_element_row.title(@dataset).downcase %>">
-          <div class="overlay-content">
-            <span class="overlay-header">
-              <span>Codeset values for <%= data_element_row.title(@dataset) %></span>
-              <a href="#" class="overlay-close">X</a>
-            </span>
-            <%- data_element_row.values.split("\n") do |line| %>
-              <span><%= line %></span><br />
-            <%- end %>
-          </div>
-        </div>
-      </div>
+    <% row_values = decompose_row_values(data_element_row.values) %>
+    <%- if row_values.dig(:extended).present? %>
+      <%= render 'shared/values_overlay', row: data_element_row, values: row_values %>
     <%- else %>
-      <%= data_element_row.values %>
+      <%= row_values.dig(:label) %>
     <%- end %>
   </td>
 </tr>

--- a/app/views/saved_items/_element.html.erb
+++ b/app/views/saved_items/_element.html.erb
@@ -39,25 +39,11 @@
     <%= data_element&.identifiability %>
   </td>
   <td data-label="Value" class="govuk-table__cell govuk-table__cell--numeric govuk-table__cell--no-break">
-    <%- if /\n/ =~ data_element.values %>
-      <div class="overlay-parent">
-        <a href="#" class="codeset" aria-describedby="codeset-<%= data_element.title.downcase %>" title="Codeset for <%= data_element.title(dataset) %>">
-          Codeset<span class="codeset-specification">for <%= data_element.title(dataset) %></span>
-        </a>
-        <div class="overlay" role="overlay" id="codeset-<%= data_element.title(dataset).downcase %>">
-          <div class="overlay-content">
-            <span class="overlay-header">
-              <span>Codeset values for <%= data_element.title(dataset) %></span>
-              <a href="#" class="overlay-close">X</a>
-            </span>
-            <%- data_element.values.split("\n") do |line| %>
-              <span><%= line %></span><br />
-            <%- end %>
-          </div>
-        </div>
-      </div>
+    <% row_values = decompose_row_values(data_element.values) %>
+    <%- if row_values.dig(:extended).present? %>
+      <%= render 'shared/values_overlay', row: data_element, values: row_values %>
     <%- else %>
-      <%= data_element.values %>
+      <%= row_values.dig(:label) %>
     <%- end %>
   </td>
 </tr>

--- a/app/views/shared/_values_overlay.html.erb
+++ b/app/views/shared/_values_overlay.html.erb
@@ -1,0 +1,17 @@
+<div class="overlay-parent">
+  <a href="#" class="codeset" aria-describedby="codeset-<%= row.title.downcase %>"
+    title="<%= values.dig(:label) %> for <%= row.title %>">
+    <%= values.dig(:label) %><span class="codeset-specification">for <%= row.title %></span>
+  </a>
+  <div class="overlay" role="overlay" id="codeset-<%= row.title.downcase %>">
+    <div class="overlay-content">
+      <span class="overlay-header">
+        <span><%= values.dig(:label) %> for <%= row.title %></span>
+        <a href="#" class="overlay-close">X</a>
+      </span>
+      <%- values.dig(:extended).each do |line| %>
+        <span><%= line %></span><br />
+      <%- end %>
+    </div>
+  </div>
+</div>

--- a/spec/system/detail_page_spec.rb
+++ b/spec/system/detail_page_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'Category hierarchy', type: :system do
   it 'Shows the elements values' do
     visit concept_path(concept)
 
-    expect(page).not_to have_link('Codeset')
+    expect(page).not_to have_link('Allowed Values')
     concept.data_elements.all.each do |element|
       expect(page).to have_text(element.values)
     end
@@ -134,10 +134,24 @@ RSpec.describe 'Category hierarchy', type: :system do
     element.update(values: "Value 1\nValue 2")
     visit concept_path(concept)
 
-    expect(page).to have_link('Codeset')
+    expect(page).to have_link('Allowed Values')
     expect(page).not_to have_text(element.values)
 
-    click_on('Codeset')
+    click_on('Allowed Values')
+    expect(page).to have_text(element.values)
+  end
+
+  it 'Shows an overlay when the value has more than 30 characters' do
+    element = concept.data_elements.all.first
+    element.update(
+      values: 'Value 1, Value 2, Value 3, Value 4, Value 5, Value 6, Value 7'
+    )
+    visit concept_path(concept)
+
+    expect(page).to have_link('Allowed Values')
+    expect(page).not_to have_text(element.values)
+
+    click_on('Allowed Values')
     expect(page).to have_text(element.values)
   end
 


### PR DESCRIPTION
# Limit 'Values' column to 30 characters

## Description

On pages that display data elements, i.e. Dataset pages, Concept pages and 'My list' pages, then the 'Values' column should display text only up to 30 characters.

Where the 'Values' text is more than 30 characters, there should be a link called 'Allowed values' that displays the text as an overlay. The 'Allowed values' link should replace the current 'Codesets' link.

## Screenshots

### My List page

![30_chars_my_list](https://user-images.githubusercontent.com/2742327/96605703-6ae76c80-12ee-11eb-994c-164fc30bf82d.jpg)

### Overlay for values > 30 characters in My List page

![30_chars_my_list_overlay_2](https://user-images.githubusercontent.com/2742327/96605756-7cc90f80-12ee-11eb-9e9b-0aad1c707f24.jpg)

### Overlay for short values arranged on multiple lines in My List page

![30_chars_my_list_overlay](https://user-images.githubusercontent.com/2742327/96605839-8eaab280-12ee-11eb-8274-1b52ddb19274.jpg)

### Concept page

![30_chars_concept](https://user-images.githubusercontent.com/2742327/96605900-9cf8ce80-12ee-11eb-86ba-91bbeee1df21.jpg)

### Overlay on concept page

![30_chars_concept_overlay](https://user-images.githubusercontent.com/2742327/96605927-a41fdc80-12ee-11eb-828b-609af4030885.jpg)

### Dataset page with < 30 characters inline values and "Allowed Values" links

<img width="1016" alt="Screen Shot 2020-10-20 at 16 10 20" src="https://user-images.githubusercontent.com/2742327/96606136-d92c2f00-12ee-11eb-97d9-67e2becf1531.png">

### Overlay on dataset page 

![30_chars_dataset_overlay](https://user-images.githubusercontent.com/2742327/96606227-f52fd080-12ee-11eb-9f81-90d396cb5777.jpg)
