### PR TITLE
Dev #648 - prevent changing email

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   before_action :set_locale
+  before_action :configure_permitted_parameters, if: :devise_controller?
   layout :layout_by_resource
 
 private
@@ -15,6 +16,12 @@ private
       'admin/application'
     else
       'application'
+    end
+  end
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:account_update) do |user_params|
+      user_params.permit(:password, :password_confirmation, :current_password)
     end
   end
 end

--- a/app/dashboards/admin_user_dashboard.rb
+++ b/app/dashboards/admin_user_dashboard.rb
@@ -68,6 +68,6 @@ class AdminUserDashboard < Administrate::BaseDashboard
   # across all pages of the admin dashboard.
   #
   def display_resource(admin_user)
-    "AdminUser #{admin_user.email}"
+    "#{admin_user.email}"
   end
 end

--- a/app/dashboards/admin_user_dashboard.rb
+++ b/app/dashboards/admin_user_dashboard.rb
@@ -68,6 +68,6 @@ class AdminUserDashboard < Administrate::BaseDashboard
   # across all pages of the admin dashboard.
   #
   def display_resource(admin_user)
-    "#{admin_user.email}"
+    admin_user.email
   end
 end

--- a/app/views/admin/admin_users/_form.html.erb
+++ b/app/views/admin/admin_users/_form.html.erb
@@ -1,0 +1,55 @@
+<%#
+# Form Partial
+
+This partial is rendered on a resource's `new` and `edit` pages,
+and renders all form fields for a resource's editable attributes.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
+  <% if page.resource.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= t(
+          "administrate.form.errors",
+          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+          resource_name: display_resource_name(page.resource_name)
+        ) %>
+      </h2>
+
+      <ul>
+        <% page.resource.errors.full_messages.each do |message| %>
+          <li class="flash-error"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field-unit field-unit--string field-unit--optional">
+    <div class="field-unit__label">
+      <label for="admin_user_email">Email</label>
+    </div>
+    <div class="field-unit__field">
+      <input type="text" value="<%= page.page_title %>" name="admin_user[email]" id="admin_user_email" <%= page.resource.persisted? ? 'disabled' : '' %>>
+    </div>
+  </div>
+
+  <% page.attributes.each do |attribute| -%>
+    <% next if attribute.name.to_s == 'email' %>
+    <div class="field-unit field-unit--<%= attribute.html_class %>">
+      <%= render_field attribute, f: f %>
+    </div>
+  <% end -%>
+
+  <div class="form-actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -16,7 +16,7 @@
 
       <div class="govuk-form-group">
         <%= f.label :email, class: 'govuk-label' %>
-        <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'govuk-input' %>
+        <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'govuk-input', disabled: true %>
         <% if f.object.errors[:email].present? %>
           <span class="govuk-error-message">
             <span class="govuk-visually-hidden">Error:</span> <%= f.object.errors[:email].map(&:capitalize).join(', ') %>


### PR DESCRIPTION
# Development

An F&E admin user cannot change their own email address or the email address of any other admin user.

When creating a new admin user the email address can be set, but again it can't be changed after creation.

## Screenshots

### Edit their own email address

![648_admin_self_edit](https://user-images.githubusercontent.com/2742327/100349349-35fec180-2fe0-11eb-9d6b-2685b946f3ee.jpeg)

### Edit someone else's email address

![648_admin_other_edit](https://user-images.githubusercontent.com/2742327/100349378-40b95680-2fe0-11eb-85e9-0d5c6ac75ef8.jpeg)

### Creating a new Admin User

![648_admin_new](https://user-images.githubusercontent.com/2742327/100349394-49aa2800-2fe0-11eb-896c-dc43c419f9e4.jpeg)
