### PR TITLE
Dev #668 - Amend landing page text

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -3,11 +3,17 @@
 # Read resources for the Category tree
 class CategoriesController < ApplicationController
   include BreadcrumbBuilder
+  include ActionView::Helpers::UrlHelper
 
   def index
     @categories = Category.real.roots
     @datasets = Dataset.all
-    @title = t('site_title')
+    @title = t('categories.index.title')
+    @description = t('categories.index.instructions',
+                     link: link_to(
+                             t('categories.index.link'),
+                             Rails.configuration.outgoing_links.dig('applying_for_access'),
+                             target: :blank))
   end
 
   def show

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -8,7 +8,7 @@ class CategoriesController < ApplicationController
   def index
     @categories = Category.real.roots
     @datasets = Dataset.all
-    @title = t('categories.index.title')
+    @title = t('site_title')
     @description = t('categories.index.instructions',
                      link: link_to(
                              t('categories.index.link'),

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -10,10 +10,9 @@ class CategoriesController < ApplicationController
     @datasets = Dataset.all
     @title = t('site_title')
     @description = t('categories.index.instructions',
-                     link: link_to(
-                             t('categories.index.link'),
-                             Rails.configuration.outgoing_links.dig('applying_for_access'),
-                             target: :blank))
+                     link: link_to(t('categories.index.link'),
+                                   Rails.configuration.outgoing_links.dig('applying_for_access'),
+                                   target: :blank))
   end
 
   def show

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,8 @@ en:
   categories:
     index:
       title: Categories
+      instructions: Use this tool to find and explore information about the data that is held in the NPD, before %{link} Department for Education (DfE) data extracts. You can search for specific data items, browse through the data items in each dataset (the data collections that feed into the NPD) or browse down via high level data categories until you find the group of data items you’re interested in. You can add data items to My List.
+      link: applying to access
     show:
       categories: Categories
       concepts: Concepts


### PR DESCRIPTION
# Amend landing page text

## Description

On the page showing 'Search', 'Datasets' and 'Categories', Insert the following explanatory text:

'Use this tool to find and explore information about the data that is held in the NPD, before applying to access Department for Education (DfE) data extracts. You can search for specific data items, browse through the data items in each dataset (the data collections that feed into the NPD) or browse down via high level data categories until you find the group of data items you’re interested in. You can add data items to My List.'

The text should be inserted between the title and the search bar, and 'applying to access' should be a hyperlink to https://www.gov.uk/guidance/how-to-access-department-for-education-dfe-data-extracts

## Screenshots

<img width="1426" alt="Screen Shot 2020-12-07 at 12 09 59" src="https://user-images.githubusercontent.com/2742327/101349922-f9f01a00-3885-11eb-8a9b-121c3f541032.png">
