### PR TITLE
Dev #670 - Remove Staging environment from Google Analytics

### DIFF
--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -1,4 +1,4 @@
-<% if (Rails.env == 'production' || Rails.env == 'staging') && usage_cookies_allowed? %>
+<% if (Rails.env == 'production') && usage_cookies_allowed? %>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=<%= google_analytics_key %>"></script>
   <%= javascript_tag nonce: true, type: 'text/javascript' do %>

--- a/app/views/shared/_google_tag_body.html.erb
+++ b/app/views/shared/_google_tag_body.html.erb
@@ -1,4 +1,4 @@
-<% if usage_cookies_allowed? -%>
+<% if (Rails.env == 'production') && usage_cookies_allowed? %>
   <!-- Google Tag Manager (noscript) -->
   <noscript>
     <iframe src="https://www.googletagmanager.com/ns.html?id=<%= google_manager_key %>"

--- a/app/views/shared/_google_tag_header.html.erb
+++ b/app/views/shared/_google_tag_header.html.erb
@@ -1,4 +1,4 @@
-<% if usage_cookies_allowed? -%>
+<% if (Rails.env == 'production') && usage_cookies_allowed? %>
   <!-- Google Tag Manager -->
   <%= javascript_tag nonce: true do %>
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
# Remove Staging environment from Google Analytics

## Description

Currently, Google Analytics data includes both the Staging and Production environments.
The Staging environment should be removed from GA, so that GA data is for the Production environment only.

## Execution

No screenshots available, in the staging environment the Google Analytics cookies will not be set and the Google Analytics javascript will not be included.
Use the browser's Developer Console to verify.