### PR TITLE
Dev #679 - Admin Area: allow admin users to delete datasets

### DIFF
--- a/app/controllers/admin/datasets_controller.rb
+++ b/app/controllers/admin/datasets_controller.rb
@@ -2,40 +2,19 @@
 
 module Admin
   class DatasetsController < Admin::ApplicationController
-    # Overwrite any of the RESTful controller actions to implement custom behavior
-    # For example, you may want to send an email after a foo is updated.
-    #
-    # def update
-    #   foo = Foo.find(params[:id])
-    #   foo.update(params[:foo])
-    #   send_foo_updated_email
-    # end
+    def destroy
+      requested_resource.data_table_tabs.destroy_all
+      requested_resource
+        .data_elements
+        .select { |data_element| data_element.datasets.count < 2 }
+        .each(&:destroy)
 
-    # Override this method to specify custom lookup behavior.
-    # This will be used to set the resource for the `show`, `edit`, and `update`
-    # actions.
-    #
-    # def find_resource(param)
-    #   Foo.find_by!(slug: param)
-    # end
-
-    # Override this if you have certain roles that require a subset
-    # this will be used to set the records shown on the `index` action.
-    #
-    # def scoped_resource
-    #  if current_user.super_admin?
-    #    resource_class
-    #  else
-    #    resource_class.with_less_stuff
-    #  end
-    # end
-
-    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
-    # for more information
-
-    # disable 'destroy' links
-    def valid_action?(name, resource = resource_class)
-      %w[destroy].exclude?(name.to_s) && super
+      if requested_resource.destroy
+        flash[:notice] = translate_with_resource('destroy.success')
+      else
+        flash[:error] = requested_resource.errors.full_messages.join('<br/>')
+      end
+      redirect_to action: :index
     end
   end
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -9,6 +9,8 @@ class Dataset < ApplicationRecord
   has_and_belongs_to_many :data_elements,
                           -> { order(unique_alias: :asc) },
                           inverse_of: :datasets, dependent: :nullify
+  has_many :data_table_tabs,
+           class_name: 'DataTable::Tab'
 
   default_scope -> { order(name: :asc) }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
       get  'abort_import(/:id)', to: 'import_datasets#abort_import',
                                  as: :abort_import
     end
-    resources :datasets, except: %i[destroy]
+    resources :datasets
     resources :admin_users
     resource :admin_user, only: [] do
       put ':id/deactivate', to: 'admin_users#deactivate', as: :deactivate


### PR DESCRIPTION
# Admin Area: allow admin users to delete datasets

## Implementation

* When clicking delete, the user is asked to confirm that they wish to delete the dataset.
* When a dataset is deleted, its data items are deleted.
* Where a data item belongs to more than one dataset and one of the datasets is deleted, the data item stays in the undeleted dataset.

## Screenshots

### Initial

<img width="812" alt="Screen Shot 2020-12-16 at 11 23 23" src="https://user-images.githubusercontent.com/2742327/102342524-424bbe00-3f91-11eb-97da-d60e272a7bc8.png">

### Confirmation

<img width="811" alt="Screen Shot 2020-12-16 at 11 23 43" src="https://user-images.githubusercontent.com/2742327/102342541-48419f00-3f91-11eb-902f-171fc72e7fa7.png">

### Final

<img width="814" alt="Screen Shot 2020-12-16 at 11 24 01" src="https://user-images.githubusercontent.com/2742327/102342554-4d9ee980-3f91-11eb-9930-bcd235fc78db.png">

