### PR TITLE
Dev #645 - Fix issue with ActiveStorage and Azure 

### DIFF
--- a/app/controllers/admin/import_datasets_controller.rb
+++ b/app/controllers/admin/import_datasets_controller.rb
@@ -92,6 +92,8 @@ module Admin
 
     def preprocess_unrecognised
       loader = DataTable::Upload.find(params['id'])
+      datasets = Dataset.where.not(id: loader.data_table_tabs.recognised.selected.pluck(:dataset_id))
+      alias_fields = Dataset.pluck(:headers_regex).uniq.map { |el| (el || '').gsub('.?', ' ') }
       back_breadcrumbs path: recognised_admin_import_datasets_path(id: loader.id)
 
       if params.permit(:submit).dig(:submit) == 'cancel'
@@ -103,7 +105,9 @@ module Admin
       end
     rescue ArgumentError => e
       Rails.logger.error(e)
-      render :unrecognised, locals: { success: false, error: e.message }
+      render :unrecognised,
+             locals: { loader: loader, datasets: datasets, alias_fields: alias_fields,
+                       success: false, error: e.message }
     end
 
     def summary

--- a/app/models/concerns/process_upload.rb
+++ b/app/models/concerns/process_upload.rb
@@ -23,7 +23,7 @@ module ProcessUpload
       rows = []
 
       workbook = Roo::Spreadsheet.open(
-        ActiveStorage::Blob.service.send(:path_for, data_table.key),
+        StringIO.new(data_table.download),
         extension: File.extname(data_table.record.file_name).gsub(/^\./, '').to_sym
       )
 


### PR DESCRIPTION
A functionality that works with a local filesystem doesn't work with Azure, generating an error on importing new datasets.

Fixed using an alternate functionality that works in both scenarios.