### PR TITLE
Dev #676 - redesign 'Sort Categories' function - introduce change log and cancel/commit

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -49,6 +49,9 @@ module Admin
     end
 
     def tree
+      custom_breadcrumbs_for(admin: true,
+                             leaf: 'Categories')
+
       @categories = Category.arrange(order: :position)
     end
 

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -2,6 +2,8 @@
 
 module Admin
   class CategoriesController < Admin::ApplicationController
+    layout :layout_by_resource
+
     helper NestableHelper
     include BreadcrumbBuilder
 
@@ -141,6 +143,14 @@ module Admin
       Category.search(search_term)
               .includes(:concepts)
               .order(:name)
+    end
+
+    def layout_by_resource
+      if params[:action] == 'tree'
+        'admin/wide'
+      else
+        'admin/application'
+      end
     end
 
     def generate_breadcrumbs

--- a/app/helpers/nestable_helper.rb
+++ b/app/helpers/nestable_helper.rb
@@ -14,7 +14,7 @@ module NestableHelper
         end
 
         content = sub_tree_nodes&.any? ? nested_tree_nodes(sub_tree_nodes) : ''
-        output += content_tag(:ol, content, class: 'list-group nested-sortable dd-list')
+        output += content_tag(:ol, content, class: 'list-group nested-sortable dd-list', 'data-id': tree_node.id)
         output
       end
     end

--- a/app/javascript/images/IconReorder.svg
+++ b/app/javascript/images/IconReorder.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="12px" height="18px" viewBox="0 0 12 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>icon Reorder</title>
+    <g id="icon-Reorder" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Group" fill="#616A6F">
+            <rect id="Rectangle-Copy-7" x="0" y="6" width="12" height="2"></rect>
+            <rect id="Rectangle-Copy-8" x="0" y="10" width="12" height="2"></rect>
+            <polygon id="Triangle" points="6 0 9 4 3 4"></polygon>
+            <polygon id="Triangle-Copy" transform="translate(6.000000, 16.000000) scale(1, -1) translate(-6.000000, -16.000000) " points="6 14 9 18 3 18"></polygon>
+        </g>
+    </g>
+</svg>

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -13,4 +13,7 @@ import '../src/govuk-frontend.js'
 import '../src/back-link.js'
 import { initCookies } from '../src/cookies.js'
 
+const images = require.context('../images', true)
+const imagePath = (name) => images(name, true)
+
 initCookies()

--- a/app/javascript/packs/nest.js
+++ b/app/javascript/packs/nest.js
@@ -1,3 +1,6 @@
+const images = require.context('../images', true)
+const imagePath = (name) => images(name, true)
+
 import '../src/nest.scss'
 
 import '../src/nest.js'

--- a/app/javascript/src/nest.js
+++ b/app/javascript/src/nest.js
@@ -12,6 +12,18 @@ jQuery(function() {
       animation: 150,
       fallbackOnBody: true,
       swapThreshold: 0.65,
+      onSort: function(event) {
+        const text = $($(event.item).find('.dd3-content')[0]).text();
+        const sortLog = (localStorage.getItem('sortLog') || '').split('|');
+
+        if (text && text != sortLog[sortLog.length - 1]) {
+          sortLog.push(text);
+          localStorage.setItem('sortLog', sortLog.join('|'));
+          $('[data-changes-log]').append(
+            '<li>"' + text + '" moved</li>'
+          );
+        }
+      },
       store: {
         /**
          * Get the order of elements. Called once during initialization.
@@ -19,8 +31,16 @@ jQuery(function() {
          * @returns {Array}
          */
         get: function (sortable) {
-          const order = localStorage.getItem(sortable.options.group.name);
-          return order ? order.split('|') : [];
+          const parent_id = sortable.el.dataset.id;
+          console.log('Getting ' + parent_id);
+
+          const savedSort = localStorage.getItem(['sort', sortable.options.group.name, parent_id].join('-'));
+          if (savedSort) {
+            const order = /^(\(\d+\))(.*)$/.exec(savedSort);
+            return order.length == 3 ? order[2].split('|') : [];
+          } else {
+            return [];
+          }
         },
 
         /**
@@ -28,12 +48,53 @@ jQuery(function() {
          * @param {Sortable}  sortable
          */
         set: function (sortable) {
-          const path = document.getElementById('tree_nodes').dataset.updatePath;
           const order = sortable.toArray();
-          const parent = sortable.el.parentElement.dataset.id;
+          const orderStorageId = ['sort', sortable.options.group.name, sortable.el.dataset.id].join('-');
+          const sequence = parseInt(localStorage.getItem('sequence') || '0');
 
-          localStorage.setItem(sortable.options.group.name, order.join('|'));
+          localStorage.setItem(orderStorageId, '(' + sequence + ')' + order.join('|'));
+          localStorage.setItem('sequence', sequence + 1);
+        }
+      }
+    });
+  }
 
+  // Recreate the list of changes
+  (localStorage.getItem('sortLog') || '').split('|').forEach(function (text) {
+    if (text) {
+      $('[data-changes-log]').append(
+        '<li>"' + text + '" moved</li>'
+      );
+    }
+  });
+
+  // Set up the "confirm" button action
+  $('[data-confirm-changes]').click(function (event) {
+    if (!$('#changes-approved')[0].checked) {
+      $('#changes-approved').parents('.govuk-form-group').addClass('govuk-form-group--error');
+      $('#changes-approved').parents('.govuk-form-group').find('.govuk-error-message').show();
+    } else {
+      const path = document.getElementById('tree_nodes').dataset.updatePath;
+      const sortKeys = Object.keys(localStorage).filter(function(val) { return /^sort-[a-z]+-.*$/.test(val) });
+      const sortedChanges = {}
+
+      $('#changes-approved').parents('.govuk-form-group').removeClass('govuk-form-group--error');
+      $('#changes-approved').parents('.govuk-form-group').find('.govuk-error-message').hide();
+
+      for (let i = 0; i < sortKeys.length; i++) {
+        let order = /^\((\d+)\)(.*)$/.exec(localStorage.getItem(sortKeys[i]));
+        if (order && order.length == 3) {
+          sortedChanges[order[1]] = [sortKeys[i], order[2]];
+        }
+      }
+
+      const ids = Object.keys(sortedChanges);
+      for (let i = 0; i < ids.length; i++) {
+        let parent_id = sortedChanges[ids[i]][0].replace(/sort-[a-z]+-/, '');
+        let order = sortedChanges[ids[i]][1].split('|');
+
+        console.log('parent_id ' + parent_id);
+        if (parent_id) {
           /**
            * Send the order of elements to the backend
            */
@@ -41,13 +102,14 @@ jQuery(function() {
             url: path,
             type: 'POST',
             data: {
-              parent: parent,
+              parent: parent_id,
               tree_nodes: order
             },
             headers: {
               'x-csrf-token': $('meta[name="csrf-token"]').attr('content')
             },
             success(data) {
+              localStorage.removeItem(sortedChanges[ids[i]][0]);
               const $flash = $('<div>')
                 .addClass('nestable-flash alert alert-success')
                 .append( $('<button>').addClass('close').data('dismiss', 'alert').html('&times;') )
@@ -61,9 +123,24 @@ jQuery(function() {
                   return $(this).remove()
                 })
             }
-          })
+          });
         }
       }
-    });
-  }
+      localStorage.setItem('sequence', '0')
+      localStorage.removeItem('sortLog')
+      $('[data-changes-log]').empty();
+    }
+  });
+
+  // Set up the "cancel" button action
+  $('[data-cancel-changes]').click(function (event) {
+    // Clear the order saved into localStorage
+    const sortKeys = Object.keys(localStorage).filter(function(val) { return /^sort-[a-z]+-.*$/.test(val) });
+    sortKeys.forEach(function (key) { localStorage.removeItem(key) });
+    localStorage.setItem('sequence', '0')
+    localStorage.removeItem('sortLog')
+
+    // Fastest way to reset the tree
+    window.location.reload();
+  });
 })

--- a/app/javascript/src/nest.scss
+++ b/app/javascript/src/nest.scss
@@ -85,6 +85,7 @@ button.dd-collapse {
   padding: 5px 10px;
   text-decoration: none;
 }
+
 .dd-handle:hover {
   color: govuk-colour('light-blue');
   background: govuk-colour('white');
@@ -280,7 +281,7 @@ button.dd-collapse {
 
 .dd3-handle:before {
   color: govuk-colour('dark-grey');
-  content: '≡';
+  content: url('../images/IconReorder.svg');
   display: block;
   font-size: 20px;
   font-weight: normal;
@@ -290,6 +291,7 @@ button.dd-collapse {
   text-indent: 0;
   top: 3px;
   width: 100%;
+  margin-top: 3px;
 }
 
 .dd3-handle:hover {

--- a/app/views/admin/categories/tree.html.erb
+++ b/app/views/admin/categories/tree.html.erb
@@ -6,33 +6,81 @@
   <%= stylesheet_pack_tag 'nest' %>
 <% end %>
 
-<header class="main-content__header" role="banner">
-  <h1 class="main-content__page-title" id="page-title">
-    <%= content_for(:title) %>
-  </h1>
 
-  <div>
-    <%= link_to(
-      t(
-        "administrate.actions.new_resource",
-        name: 'category'
-      ),
-      [:new, :admin, :category],
-      class: "button",
-    ) if valid_action?(:new) && show_action?(:new, new_resource) %>
+<header class="main-content__header govuk-!-padding-left-0 govuk-!-border-0" role="banner">
+  <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
+    <h1 class="govuk-heading-l govuk-!-margin-top-5 govuk-!-margin-bottom-5" id="page-title">
+      <%= content_for(:title) %>
+    </h1>
   </div>
 </header>
 
 <section id="nestable" class="main-content__body main-content__body--flush">
-  <% if @categories.present? %>
-    <div id="tree_nodes" class="dd" data-update-path="<%= sort_admin_categories_path %>">
-      <ol id="categories" class="list-group nested-sortable dd-list">
-        <%= nested_tree_nodes @categories %>
-      </ol>
+  <div class="govuk-grid-row govuk-!-margin-top-0">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0">
+      <% if @categories.present? %>
+        <div id="tree_nodes" class="dd" data-update-path="<%= sort_admin_categories_path %>">
+          <ol id="categories" class="list-group nested-sortable dd-list">
+            <%= nested_tree_nodes @categories %>
+          </ol>
+        </div>
+      <% else %>
+        <h3>There are currently no categories.</h3>
+      <% end %>
     </div>
-  <% else %>
-    <h3>There are currently no categories.</h3>
-  <% end %>
+    <div class="govuk-grid-column-one-third govuk-!-margin-top-5">
+      <!--<div class="govuk-top-border govuk-border-bottom">
+        <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
+          <%= t('actions.filters') %>
+        </p>
+      </div> -->
+      <div class="govuk-top-border govuk-border-bottom">
+        <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
+          <%= t('actions.actions') %>
+        </p>
+        <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
+          <%= link_to(t('admin.categories.actions.create'),
+                      [:new, :admin, :category],
+                      class: %w[govuk-!-margin-bottom-1]
+                     ) if valid_action?(:new) && show_action?(:new, Category.new) %>
+        </p>
+        <!-- <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
+          <%= link_to(t('admin.concepts.actions.create'),
+                      [:new, :admin, :concept],
+                      class: %w[govuk-!-margin-bottom-1]
+                     ) if valid_action?(:new) && show_action?(:new, Concept.new) %>
+        </p> -->
+      </div>
+      <div>
+        <div>
+          <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
+            <%= t('actions.change_log') %>
+          </p>
+        </div>
+        <div>
+          <ul class="govuk-list govuk-list--bullet changelog" data-changes-log>
+          </ul>
+        </div>
+        <div class="govuk-form-group govuk-checkboxes govuk-checkboxes--small">
+          <span id="confirm-error" class="govuk-error-message" style="display: none">
+            <span class="govuk-visually-hidden">Error:</span> Please confirm that the changes have been reviewed and approved
+          </span>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input" id="changes-approved" name="changes-approved" type="checkbox" required="true">
+            <label class="govuk-label govuk-checkboxes__label govuk-!-margin-left-5 govuk-!-padding-top-0" for="organisation">
+              <%= t('forms.changes_approved') %>
+            </label>
+          </div>
+        </div>
+        <div>
+          <button type="submit" class="govuk-button" id="confirm-changes"
+                  data-confirm-changes data-validate="#changes-approved"><%= t('forms.confirm') %></button>
+          <button type="submit" class="govuk-button govuk-button--secondary" id="cancel-changes"
+                  data-cancel-changes><%= t('forms.cancel') %></button>
+        </div>
+      </div>
+    </div>
+  </div>
 </section>
 
 <%= javascript_pack_tag 'nest' %>

--- a/app/views/admin/data_elements/orphaned.html.erb
+++ b/app/views/admin/data_elements/orphaned.html.erb
@@ -50,7 +50,7 @@
 
       <div class="govuk-grid-column-one-third">
         <p class="govuk-heading-s govuk-!-font-size-16 govuk-top-border govuk-!-padding-top-4">
-          <%= t('admin.data_elements.orphaned.actions') %>
+          <%= t('actions.actions') %>
         </p>
         <p class="govuk-!-font-size-16 govuk-!-margin-bottom-1">
           <%= t('admin.data_elements.orphaned.assign_to_concept.title') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,9 @@ en:
       dataset: Datasets
   staging_warning: You are currently on the Find and Explore staging environment
   actions:
-    title: Actions to perform
+    actions: Actions to perform
+    filter: Filter
+    change_log: Change log
   beta_banner:
     text: This is a new service – we are improving how the metadata from the NPD Data Tables can be displayed and therefore the content might change. Your %{link} will help us to improve it.
     link: feedback
@@ -149,6 +151,12 @@ en:
       nestable:
         success: Tree updated
         error: Error while updating the tree
+    categories:
+      actions:
+        create: Create a new category
+    concepts:
+      actions:
+        create: Create a new concept
     data_elements:
       title: Data Items
       reindex:
@@ -158,7 +166,6 @@ en:
         success:  The search index was refreshed correctly
       orphaned:
         title: Orphaned Data Items
-        actions: Actions to perform
         assign_to_concept:
           title: Assign to concept
           subtitle: Enter concept name to be assigned
@@ -220,6 +227,7 @@ en:
     confirm_and_continue: Confirm and continue
     cancel: Cancel
     or: or
+    changes_approved: Changes have been approved
 
   date:
     formats:


### PR DESCRIPTION
# Redesign 'Sort Categories' function - introduce change log and cancel/commit

## Development

* Restyle the 'Sort Categories and Concepts' page to add a new right hand menu as in the UED
* the 'Change log' displays a list of the drag and drop actions that have been made, but the actions aren't permanently applied 'Changes have been approved' is checked and the 'Confirm' button is clicked;
* clicking the 'Cancel' button clears the change log and returns the categories and concepts to the state prior to the actions listed in the change log.

## Screenshots

### Initial status

![676_initial](https://user-images.githubusercontent.com/2742327/103694334-bc6cd280-4f92-11eb-9771-6aba6a7113a6.jpg)

### Change log

![676_log](https://user-images.githubusercontent.com/2742327/103694349-c393e080-4f92-11eb-8d74-f8afb23c32ed.jpg)

### Error when trying to commit without checking the checkbox

![676_error_message](https://user-images.githubusercontent.com/2742327/103694382-ce4e7580-4f92-11eb-8221-3fa2ee62bc65.jpg)
