### PR TITLE
Dev #676 - Admin area: redesign 'Sort Categories' function - additional info, collapse and concepts

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -7,7 +7,7 @@ module Admin
     helper NestableHelper
     include BreadcrumbBuilder
 
-    before_action :generate_breadcrumbs, only: %i[show edit]
+    before_action :generate_breadcrumbs, only: %i[new create show edit update]
 
     # To customize the behavior of this controller,
     # you can overwrite any of the RESTful actions. For example:
@@ -52,7 +52,8 @@ module Admin
       custom_breadcrumbs_for(admin: true,
                              leaf: 'Categories')
 
-      @categories = Category.arrange(order: :position)
+      # @categories = Category.includes(concepts: :data_elements }).arrange(order: :position)
+      @categories = Category.roots.includes(concepts: :data_elements)
     end
 
     def sort
@@ -149,7 +150,7 @@ module Admin
     end
 
     def layout_by_resource
-      if %w[tree show edit update].include?(params[:action])
+      if %w[tree new create show edit update].include?(params[:action])
         'admin/wide'
       else
         'admin/application'
@@ -159,7 +160,7 @@ module Admin
     def generate_breadcrumbs
       custom_breadcrumbs_for(admin: true,
                              steps: [{ name: 'Categories', path: tree_admin_categories_path }],
-                             leaf: requested_resource.name)
+                             leaf: params[:id].present? ? requested_resource.name : params[:action].titleize)
     end
   end
 end

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -149,7 +149,7 @@ module Admin
     end
 
     def layout_by_resource
-      if params[:action] == 'tree'
+      if %w[tree show edit update].include?(params[:action])
         'admin/wide'
       else
         'admin/application'
@@ -157,7 +157,9 @@ module Admin
     end
 
     def generate_breadcrumbs
-      admin_breadcrumbs_for(category_leaf: requested_resource)
+      custom_breadcrumbs_for(admin: true,
+                             steps: [{ name: 'Categories', path: tree_admin_categories_path }],
+                             leaf: requested_resource.name)
     end
   end
 end

--- a/app/controllers/admin/concepts_controller.rb
+++ b/app/controllers/admin/concepts_controller.rb
@@ -2,9 +2,11 @@
 
 module Admin
   class ConceptsController < Admin::ApplicationController
+    layout :layout_by_resource
+
     include BreadcrumbBuilder
 
-    before_action :generate_breadcrumbs, only: %i[show edit]
+    before_action :generate_breadcrumbs, only: %i[new create show edit update]
 
     # To customize the behavior of this controller,
     # you can overwrite any of the RESTful actions. For example:
@@ -47,6 +49,14 @@ module Admin
 
   private
 
+    def layout_by_resource
+      if %w[new create show edit update].include?(params[:action])
+        'admin/wide'
+      else
+        'admin/application'
+      end
+    end
+
     def find_resources(search_term = nil)
       return Concept.all.order(:name) if search_term.blank?
 
@@ -56,7 +66,9 @@ module Admin
     end
 
     def generate_breadcrumbs
-      admin_breadcrumbs_for(category_leaf: requested_resource.category, concept: requested_resource)
+      custom_breadcrumbs_for(admin: true,
+                             steps: [{ name: 'Concepts', path: tree_admin_categories_path }],
+                             leaf: params[:id].present? ? requested_resource.name : params[:action].titleize)
     end
   end
 end

--- a/app/helpers/nestable_helper.rb
+++ b/app/helpers/nestable_helper.rb
@@ -7,20 +7,24 @@ module NestableHelper
     return if tree_nodes.nil?
 
     nodes = tree_nodes.map do |tree_node, sub_tree_nodes|
-      li_classes = 'list-group-item dd-item dd3-item'
+      li_classes = 'list-group-item dd-item dd3-item dd-collapsed'
 
       content_tag(:li, class: li_classes, 'data-id': tree_node.id) do
         output = content_tag :div, 'drag', class: 'dd-handle dd3-handle'
-        output += content_tag(:div, { class: 'dd3-content' }, false) do
-          content = content_tag :div, object_label(tree_node), class: %i[dd-label]
-          content += content_tag :div, class: %i[dd-extras] do
-            extras = children_count(sub_tree_nodes)
-            extras += link_to 'Edit', edit_admin_category_path(tree_node.id), class: %i[dd-link]
-            extras += link_to 'View detail', '#', class: %i[dd-link view-detail]
-            extras
+        output += button_tag '+', class: 'dd-expand', data: { action: 'expand' }
+        output += button_tag '-', class: 'dd-collapse', data: { action: 'collapse' }
+        output += content_tag :div, class: 'dd3-content' do
+          content_tag :div, class: %w[dd-flex] do
+            content = content_tag :div, object_label(tree_node), class: %i[dd-label]
+            content += content_tag :div, class: %i[dd-extras] do
+              extras = children_count(sub_tree_nodes)
+              extras += link_to 'Edit', edit_admin_category_path(tree_node.id), class: %i[dd-link]
+              extras += link_to 'View detail', '#', class: %i[dd-link view-detail]
+              extras
+            end
+            content
           end
-          content
-        end.html_safe
+        end
 
         output += content_tag :div, class: %i[dd-details hidden] do
           rows = content_tag :div, class: %i[details-row] do

--- a/app/helpers/nestable_helper.rb
+++ b/app/helpers/nestable_helper.rb
@@ -3,50 +3,35 @@
 module NestableHelper
   include ActionView::Helpers::TranslationHelper
 
-  def nested_tree_nodes(tree_nodes = [])
-    return if tree_nodes.nil?
+  def nested_tree_nodes(categories = [])
+    return '' if categories.empty?
 
-    nodes = tree_nodes.map do |tree_node, sub_tree_nodes|
-      li_classes = 'list-group-item dd-item dd3-item dd-collapsed'
+    nodes = categories.map do |category|
+      li_classes = %w[list-group-item dd-item dd3-item dd-collapsed]
+      li_classes.push 'dd-concept' if category.children.empty? && category.concepts.any?
 
-      content_tag(:li, class: li_classes, 'data-id': tree_node.id) do
-        output = content_tag :div, 'drag', class: 'dd-handle dd3-handle'
-        output += button_tag '+', class: 'dd-expand', data: { action: 'expand' }
-        output += button_tag '-', class: 'dd-collapse', data: { action: 'collapse' }
-        output += content_tag :div, class: 'dd3-content' do
+      content_tag :li, class: li_classes, 'data-id': category.id do
+        output = content_tag :div, 'drag', class: %w[dd-handle dd3-handle]
+        output += button_tag '+', class: %w[dd-expand], data: { action: 'expand' }
+        output += button_tag '-', class: %w[dd-collapse], data: { action: 'collapse' }
+        output += content_tag :div, class: %w[dd3-content] do
           content_tag :div, class: %w[dd-flex] do
-            content = content_tag :div, object_label(tree_node), class: %i[dd-label]
-            content += content_tag :div, class: %i[dd-extras] do
-              extras = children_count(sub_tree_nodes)
-              extras += link_to 'Edit', edit_admin_category_path(tree_node.id), class: %i[dd-link]
-              extras += link_to 'View detail', '#', class: %i[dd-link view-detail]
+            content = content_tag :div, object_label(category), class: %w[dd-label]
+            content += content_tag :div, class: %w[dd-extras] do
+              extras = children_count(category)
+              extras += link_to 'Edit', edit_admin_category_path(category.id), class: %w[dd-link]
+              extras += link_to 'View detail', '#', class: %w[dd-link view-detail]
               extras
             end
             content
           end
         end
 
-        output += content_tag :div, class: %i[dd-details hidden] do
-          rows = content_tag :div, class: %i[details-row] do
-            row = content_tag :span, 'Description', class: %i[title]
-            row += content_tag :span, tree_node.description, class: %i[content]
-            row
-          end
-          rows += content_tag :div, class: %i[details-row] do
-            row = content_tag :span, 'Created', class: %i[title]
-            row += content_tag :span, l(tree_node.created_at, format: :npd_long), class: %i[content]
-            row
-          end
-          rows += content_tag :div, class: %i[details-row] do
-            row = content_tag :span, 'Updated', class: %i[title]
-            row += content_tag :span, l(tree_node.updated_at, format: :npd_long), class: %i[content]
-            row
-          end
-          rows
-        end
+        output += details(category)
 
-        content = sub_tree_nodes&.any? ? nested_tree_nodes(sub_tree_nodes) : ''
-        output += content_tag(:ol, content, class: 'list-group nested-sortable dd-list', 'data-id': tree_node.id)
+        content = nested_tree_nodes(category.children)
+        content += nested_concepts(category)
+        output += content_tag(:ol, content.html_safe, class: %w[list-group nested-sortable dd-list], 'data-id': category.id)
         output
       end
     end
@@ -54,11 +39,63 @@ module NestableHelper
     nodes.join.html_safe
   end
 
-  def object_label(tree_node)
-    tree_node.name
+  def nested_concepts(category)
+    nodes = category.concepts.map do |concept|
+      li_classes = %w[list-group-item dd-item dd4-item dd-collapsed dd-concept]
+
+      content_tag :li, class: li_classes, 'data-id': concept.id do
+        output = content_tag :div, 'drag', class: %w[dd-handle dd4-handle]
+        output += content_tag :div, class: %w[dd4-content] do
+          content_tag :div, class: %w[dd-flex] do
+            content = content_tag :div, object_label(concept), class: %w[dd-label]
+            content += content_tag :div, class: %w[dd-extras] do
+              extras = content_tag :span, "#{concept.data_elements.count} data items", class: %w[dd-count]
+              extras += link_to 'Edit', edit_admin_concept_path(concept.id), class: %w[dd-link]
+              extras += link_to 'View detail', '#', class: %w[dd-link view-detail]
+              extras
+            end
+            content
+          end
+        end
+
+        output += details(concept)
+        output
+      end
+    end
+
+    nodes.join.html_safe
   end
 
-  def children_count(sub_tree_nodes)
-    content_tag :span, "#{sub_tree_nodes.count} categories", class: %i[dd-count]
+  def object_label(category)
+    category.name
+  end
+
+  def children_count(category)
+    if category.concepts.any?
+      content_tag :span, "#{category.concepts.count} concepts", class: %w[dd-count]
+    else
+      content_tag :span, "#{category.children.count} categories", class: %w[dd-count]
+    end
+  end
+
+  def details(element)
+    content_tag :div, class: %w[dd-details hidden] do
+      rows = content_tag :div, class: %w[details-row] do
+        row = content_tag :span, 'Description', class: %w[title]
+        row += content_tag :span, element.description, class: %w[content]
+        row
+      end
+      rows += content_tag :div, class: %w[details-row] do
+        row = content_tag :span, 'Created', class: %w[title]
+        row += content_tag :span, l(element.created_at, format: :npd_long), class: %w[content]
+        row
+      end
+      rows += content_tag :div, class: %w[details-row] do
+        row = content_tag :span, 'Updated', class: %w[title]
+        row += content_tag :span, l(element.updated_at, format: :npd_long), class: %w[content]
+        row
+      end
+      rows
+    end
   end
 end

--- a/app/helpers/nestable_helper.rb
+++ b/app/helpers/nestable_helper.rb
@@ -14,7 +14,7 @@ module NestableHelper
         output = content_tag :div, 'drag', class: %w[dd-handle dd3-handle]
         output += button_tag '+', class: %w[dd-expand], data: { action: 'expand' }
         output += button_tag '-', class: %w[dd-collapse], data: { action: 'collapse' }
-        output += content_tag :div, class: %w[dd3-content] do
+        output += content_tag :div, class: %w[dd-content dd3-content] do
           content_tag :div, class: %w[dd-flex] do
             content = content_tag :div, object_label(category), class: %w[dd-label]
             content += content_tag :div, class: %w[dd-extras] do
@@ -43,9 +43,9 @@ module NestableHelper
     nodes = category.concepts.map do |concept|
       li_classes = %w[list-group-item dd-item dd4-item dd-collapsed dd-concept]
 
-      content_tag :li, class: li_classes, 'data-id': concept.id do
+      content_tag :li, class: li_classes, 'data-id': "concept-#{concept.id}" do
         output = content_tag :div, 'drag', class: %w[dd-handle dd4-handle]
-        output += content_tag :div, class: %w[dd4-content] do
+        output += content_tag :div, class: %w[dd-content dd4-content] do
           content_tag :div, class: %w[dd-flex] do
             content = content_tag :div, object_label(concept), class: %w[dd-label]
             content += content_tag :div, class: %w[dd-extras] do

--- a/app/helpers/nestable_helper.rb
+++ b/app/helpers/nestable_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module NestableHelper
+  include ActionView::Helpers::TranslationHelper
+
   def nested_tree_nodes(tree_nodes = [])
     return if tree_nodes.nil?
 
@@ -9,8 +11,34 @@ module NestableHelper
 
       content_tag(:li, class: li_classes, 'data-id': tree_node.id) do
         output = content_tag :div, 'drag', class: 'dd-handle dd3-handle'
-        output += content_tag :div, class: 'dd3-content' do
-          link_to object_label(tree_node), edit_admin_category_path(tree_node.id)
+        output += content_tag(:div, { class: 'dd3-content' }, false) do
+          content = content_tag :div, object_label(tree_node), class: %i[dd-label]
+          content += content_tag :div, class: %i[dd-extras] do
+            extras = children_count(sub_tree_nodes)
+            extras += link_to 'Edit', edit_admin_category_path(tree_node.id), class: %i[dd-link]
+            extras += link_to 'View detail', '#', class: %i[dd-link view-detail]
+            extras
+          end
+          content
+        end.html_safe
+
+        output += content_tag :div, class: %i[dd-details hidden] do
+          rows = content_tag :div, class: %i[details-row] do
+            row = content_tag :span, 'Description', class: %i[title]
+            row += content_tag :span, tree_node.description, class: %i[content]
+            row
+          end
+          rows += content_tag :div, class: %i[details-row] do
+            row = content_tag :span, 'Created', class: %i[title]
+            row += content_tag :span, l(tree_node.created_at, format: :npd_long), class: %i[content]
+            row
+          end
+          rows += content_tag :div, class: %i[details-row] do
+            row = content_tag :span, 'Updated', class: %i[title]
+            row += content_tag :span, l(tree_node.updated_at, format: :npd_long), class: %i[content]
+            row
+          end
+          rows
         end
 
         content = sub_tree_nodes&.any? ? nested_tree_nodes(sub_tree_nodes) : ''
@@ -24,5 +52,9 @@ module NestableHelper
 
   def object_label(tree_node)
     tree_node.name
+  end
+
+  def children_count(sub_tree_nodes)
+    content_tag :span, "#{sub_tree_nodes.count} categories", class: %i[dd-count]
   end
 end

--- a/app/javascript/src/_colours.scss
+++ b/app/javascript/src/_colours.scss
@@ -1,3 +1,4 @@
 $black-overlay: rgba(0, 0, 0, .75);
 $grey-0: #333;
 $grey-1-2: #999;
+$light-yellow: #ffee77;

--- a/app/javascript/src/nest.js
+++ b/app/javascript/src/nest.js
@@ -170,6 +170,13 @@ function initializeCollapsible() {
   $('[data-action="expand"]').click(function (event) {
     $(event.currentTarget).parent('.dd-item').removeClass('dd-collapsed');
   });
+  $('#expand-categories').change(function (event) {
+    if (event.currentTarget.checked) {
+      $('.dd-item').removeClass('dd-collapsed');
+    } else {
+      $('.dd-item').addClass('dd-collapsed');
+    }
+  });
 }
 
 jQuery(function() {

--- a/app/javascript/src/nest.js
+++ b/app/javascript/src/nest.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import Sortable from 'sortablejs';
 
-jQuery(function() {
+function initializeSortable() {
   const nestedSortables = document.querySelectorAll('.nested-sortable');
 
   // Loop through each nested sortable element
@@ -13,7 +13,7 @@ jQuery(function() {
       fallbackOnBody: true,
       swapThreshold: 0.65,
       onSort: function(event) {
-        const text = $($(event.item).find('.dd3-content')[0]).text();
+        const text = $($(event.item).find('.dd3-content .dd-label')[0]).text();
         const sortLog = (localStorage.getItem('sortLog') || '').split('|');
 
         if (text && text != sortLog[sortLog.length - 1]) {
@@ -32,9 +32,8 @@ jQuery(function() {
          */
         get: function (sortable) {
           const parent_id = sortable.el.dataset.id;
-          console.log('Getting ' + parent_id);
-
           const savedSort = localStorage.getItem(['sort', sortable.options.group.name, parent_id].join('-'));
+
           if (savedSort) {
             const order = /^(\(\d+\))(.*)$/.exec(savedSort);
             return order.length == 3 ? order[2].split('|') : [];
@@ -58,7 +57,9 @@ jQuery(function() {
       }
     });
   }
+}
 
+function initializeChangeLog() {
   // Recreate the list of changes
   (localStorage.getItem('sortLog') || '').split('|').forEach(function (text) {
     if (text) {
@@ -66,6 +67,20 @@ jQuery(function() {
         '<li>"' + text + '" moved</li>'
       );
     }
+  });
+}
+
+function initializeCommitChanges() {
+  // Set up the "cancel" button action
+  $('[data-cancel-changes]').click(function (event) {
+    // Clear the order saved into localStorage
+    const sortKeys = Object.keys(localStorage).filter(function(val) { return /^sort-[a-z]+-.*$/.test(val) });
+    sortKeys.forEach(function (key) { localStorage.removeItem(key) });
+    localStorage.setItem('sequence', '0')
+    localStorage.removeItem('sortLog')
+
+    // Fastest way to reset the tree
+    window.location.reload();
   });
 
   // Set up the "confirm" button action
@@ -131,16 +146,26 @@ jQuery(function() {
       $('[data-changes-log]').empty();
     }
   });
+}
 
-  // Set up the "cancel" button action
-  $('[data-cancel-changes]').click(function (event) {
-    // Clear the order saved into localStorage
-    const sortKeys = Object.keys(localStorage).filter(function(val) { return /^sort-[a-z]+-.*$/.test(val) });
-    sortKeys.forEach(function (key) { localStorage.removeItem(key) });
-    localStorage.setItem('sequence', '0')
-    localStorage.removeItem('sortLog')
-
-    // Fastest way to reset the tree
-    window.location.reload();
+function initializeViewDetails() {
+  $('.view-detail').click(function (event) {
+    event.preventDefault();
+    const link = $(event.currentTarget);
+    const details = link.parents('.dd3-content').siblings('.dd-details');
+    if (details.hasClass('hidden')) {
+      details.removeClass('hidden');
+      link.text('Hide details');
+    } else {
+      details.addClass('hidden');
+      link.text('View details');
+    }
   });
+}
+
+jQuery(function() {
+  initializeSortable();
+  initializeChangeLog();
+  initializeCommitChanges();
+  initializeViewDetails();
 })

--- a/app/javascript/src/nest.js
+++ b/app/javascript/src/nest.js
@@ -13,7 +13,7 @@ function initializeSortable() {
       fallbackOnBody: true,
       swapThreshold: 0.65,
       onSort: function(event) {
-        const text = $($(event.item).find('.dd3-content .dd-label')[0]).text();
+        const text = $($(event.item).find('.dd-content .dd-label')[0]).text();
         const sortLog = (localStorage.getItem('sortLog') || '').split('|');
 
         if (text && text != sortLog[sortLog.length - 1]) {

--- a/app/javascript/src/nest.js
+++ b/app/javascript/src/nest.js
@@ -163,9 +163,19 @@ function initializeViewDetails() {
   });
 }
 
+function initializeCollapsible() {
+  $('[data-action="collapse"]').click(function (event) {
+    $(event.currentTarget).parent('.dd-item').addClass('dd-collapsed');
+  });
+  $('[data-action="expand"]').click(function (event) {
+    $(event.currentTarget).parent('.dd-item').removeClass('dd-collapsed');
+  });
+}
+
 jQuery(function() {
   initializeSortable();
   initializeChangeLog();
   initializeCommitChanges();
   initializeViewDetails();
+  initializeCollapsible();
 })

--- a/app/javascript/src/nest.js
+++ b/app/javascript/src/nest.js
@@ -5,7 +5,7 @@ function initializeSortable() {
   const nestedSortables = document.querySelectorAll('.nested-sortable');
 
   // Loop through each nested sortable element
-  for (var i = 0; i < nestedSortables.length; i++) {
+  for (let i = 0; i < nestedSortables.length; i++) {
     new Sortable(nestedSortables[i], {
       group: 'nested',
       handle: '.dd-handle',
@@ -172,7 +172,17 @@ function initializeCollapsible() {
   });
   $('#expand-categories').change(function (event) {
     if (event.currentTarget.checked) {
+      $('.dd-item:not(.dd-concept)').removeClass('dd-collapsed');
+    } else {
+      $('.dd-item:not(.dd-concept)').addClass('dd-collapsed');
+    }
+  });
+  $('#expand-concepts').change(function (event) {
+    if (event.currentTarget.checked) {
+      document.getElementById('expand-categories').checked = true;
       $('.dd-item').removeClass('dd-collapsed');
+    } else if (document.getElementById('expand-categories').checked) {
+      $('.dd-item.dd-concept').addClass('dd-collapsed');
     } else {
       $('.dd-item').addClass('dd-collapsed');
     }

--- a/app/javascript/src/nest.scss
+++ b/app/javascript/src/nest.scss
@@ -175,13 +175,12 @@ button.dd-collapse {
     overflow: hidden;
     text-align: left;
     text-overflow: ellipsis;
-    width: 49%;
   }
 
   .dd-extras {
     display: inline-block;
     text-align: right;
-    width: 39%;
+    min-width: max-content;
     vertical-align: top;
 
     .dd-count {
@@ -215,6 +214,30 @@ button.dd-collapse {
       text-align: left;
       vertical-align: top;
       width: 79%;
+    }
+  }
+}
+
+.legend {
+  display: block;
+  width: 100%;
+
+  .legend-entry {
+    padding-left: 0px;
+    padding-right: 30px;
+
+    .legend-icon {
+      border: 1px solid govuk-colour('dark-grey');
+      display: inline-block;
+      height: 25px;
+      margin-right: 10px;
+      width: 25px;
+    }
+    .legend-icon-grey {
+      background-color: govuk-colour('light-grey');
+    }
+    .legend-icon-yellow {
+      background-color: $light-yellow;
     }
   }
 }

--- a/app/javascript/src/nest.scss
+++ b/app/javascript/src/nest.scss
@@ -162,6 +162,55 @@ button.dd-collapse {
   box-shadow: 2px 4px 6px 0 rgba(0,0,0,.1);
 }
 
+.dd-label {
+  display: inline-block;
+  height: 1.5em;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  width: 49%;
+}
+
+.dd-extras {
+  display: inline-block;
+  text-align: right;
+  width: 49%;
+  vertical-align: top;
+
+  .dd-count {
+    display: inline-block;
+    font-weight: normal;
+  }
+
+  .dd-link {
+    padding-left: 6px;
+  }
+}
+
+.dd-details {
+  padding-left: 60px;
+
+  .details-row {
+    display: block;
+
+    .title {
+      display: inline-block;
+      font-weight: bold;
+      padding-right: .5em;
+      text-align: right;
+      vertical-align: top;
+      width: 15%;
+    }
+
+    .content {
+      display: inline-block;
+      text-align: left;
+      vertical-align: top;
+      width: 79%;
+    }
+  }
+}
+
 // Nestable Extras
 
 .nestable-lists {
@@ -238,7 +287,6 @@ button.dd-collapse {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   color: $grey-0;
-  display: block;
   font-weight: bold;
   height: 30px;
   margin: 5px 0;

--- a/app/javascript/src/nest.scss
+++ b/app/javascript/src/nest.scss
@@ -207,7 +207,7 @@ button.dd-collapse {
       padding-right: .5em;
       text-align: right;
       vertical-align: top;
-      width: 15%;
+      width: 19%;
     }
 
     .content {
@@ -307,11 +307,35 @@ button.dd-collapse {
   color: govuk-colour('light-blue');
 }
 
-.dd-dragel > .dd3-item > .dd3-content {
+.dd4-content {
+  background: -webkit-gradient(linear, left top, left bottom, from($light-yellow), to(govuk-colour('yellow')));
+  background: -webkit-linear-gradient(top, $light-yellow 0%, govuk-colour('yellow') 100%);
+  background: -o-linear-gradient(top, $light-yellow 0%, govuk-colour('yellow') 100%);
+  background: linear-gradient(to bottom, $light-yellow 0%, govuk-colour('yellow') 100%);
+  background: $light-yellow;
+  border: 1px solid govuk-colour('yellow');
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  color: $grey-0;
+  font-weight: bold;
+  height: 30px;
+  margin: 5px 0;
+  padding: 5px 10px 5px 40px;
+  text-decoration: none;
+}
+
+.dd4-content:hover {
+  background: $light-yellow;
+  color: govuk-colour('dark-grey');
+}
+
+.dd-dragel > .dd3-item > .dd3-content, .dd-dragel > .dd4-item > .dd4-content {
   margin: 0;
 }
 
-.dd3-item > button {
+.dd3-item > button, .dd4-item > button {
   margin-left: 30px;
 }
 
@@ -335,7 +359,27 @@ button.dd-collapse {
   width: 30px;
 }
 
-.dd3-handle:before {
+.dd4-handle {
+  background: -webkit-gradient(linear, left top, left bottom, from($light-yellow), to(govuk-colour('yellow')));
+  background: -webkit-linear-gradient(top, $light-yellow 0%, govuk-colour('yellow') 100%);
+  background: -o-linear-gradient(top, $light-yellow 0%, govuk-colour('yellow') 100%);
+  background: linear-gradient(to bottom, $light-yellow 0%, govuk-colour('yellow') 100%);
+  background: $light-yellow;
+  border: 1px solid govuk-colour('yellow');
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  cursor: pointer;
+  left: 0;
+  margin: 0;
+  overflow: hidden;
+  position: absolute;
+  top: 0;
+  text-indent: 100px;
+  white-space: nowrap;
+  width: 30px;
+}
+
+.dd3-handle:before, .dd4-handle:before {
   color: govuk-colour('dark-grey');
   content: url('../images/IconReorder.svg');
   display: block;
@@ -354,24 +398,29 @@ button.dd-collapse {
   background: govuk-colour('light-grey');
 }
 
-.dd3-content .links {
+.dd4-handle:hover {
+  background: govuk-colour('yellow');
+}
+
+
+.dd3-content .links, .dd4-content .links {
   width: auto;
 }
 
-.dd3-content ul.inline.actions {
+.dd3-content ul.inline.actions, .dd4-content ul.inline.actions {
   margin: 0;
   padding: 0;
   list-style: none;
   display: block;
 }
 
-.dd3-content ul.inline.actions li a {
+.dd3-content ul.inline.actions li a, .dd4-content ul.inline.actions li a {
   width: 14px;
   height: 16px;
   text-decoration: none;
 }
 
-.dd3-content ul.inline.actions li a:hover {
+.dd3-content ul.inline.actions li a:hover, .dd4-content ul.inline.actions li a:hover {
   text-decoration: none;
 }
 

--- a/app/javascript/src/nest.scss
+++ b/app/javascript/src/nest.scss
@@ -26,6 +26,8 @@
 }
 
 button.dd-expand, button.dd-collapse {
+  border: 1px solid govuk-colour('mid-grey');
+
   &:before {
     color: govuk-colour('dark-grey');
   }
@@ -162,28 +164,34 @@ button.dd-collapse {
   box-shadow: 2px 4px 6px 0 rgba(0,0,0,.1);
 }
 
-.dd-label {
-  display: inline-block;
-  height: 1.5em;
-  overflow: hidden;
-  text-align: left;
-  text-overflow: ellipsis;
-  width: 49%;
-}
+.dd-flex {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 
-.dd-extras {
-  display: inline-block;
-  text-align: right;
-  width: 49%;
-  vertical-align: top;
-
-  .dd-count {
+  .dd-label {
     display: inline-block;
-    font-weight: normal;
+    height: 1.5em;
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+    width: 49%;
   }
 
-  .dd-link {
-    padding-left: 6px;
+  .dd-extras {
+    display: inline-block;
+    text-align: right;
+    width: 39%;
+    vertical-align: top;
+
+    .dd-count {
+      display: inline-block;
+      font-weight: normal;
+    }
+
+    .dd-link {
+      padding-left: 6px;
+    }
   }
 }
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -19,6 +19,7 @@ class Category < ApplicationRecord
   before_destroy :reassign_concepts, prepend: true
   before_create :sort_categories
 
+  default_scope { order(position: :asc) }
   scope :real, -> { where.not(name: 'No Category') }
 
   has_ancestry orphan_strategy: :rootify

--- a/app/views/admin/categories/tree.html.erb
+++ b/app/views/admin/categories/tree.html.erb
@@ -7,17 +7,17 @@
 <% end %>
 
 
-<header class="main-content__header govuk-!-padding-left-0 govuk-!-border-0" role="banner">
-  <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-    <h1 class="govuk-heading-l govuk-!-margin-top-5 govuk-!-margin-bottom-5" id="page-title">
-      <%= content_for(:title) %>
-    </h1>
-  </div>
-</header>
+<div class="govuk-grid-row govuk-!-margin-top-0">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0">
+    <header class="main-content__header govuk-!-padding-left-0 govuk-!-border-0" role="banner">
+      <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
+        <h1 class="govuk-heading-l govuk-!-margin-top-2 govuk-!-margin-bottom-5" id="page-title">
+          <%= content_for(:title) %>
+        </h1>
+      </div>
+    </header>
 
-<section id="nestable" class="main-content__body main-content__body--flush">
-  <div class="govuk-grid-row govuk-!-margin-top-0">
-    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0">
+    <section id="nestable" class="main-content__body main-content__body--flush">
       <% if @categories.present? %>
         <div id="tree_nodes" class="dd" data-update-path="<%= sort_admin_categories_path %>">
           <ol id="categories" class="list-group nested-sortable dd-list">
@@ -27,34 +27,35 @@
       <% else %>
         <h3>There are currently no categories.</h3>
       <% end %>
-    </div>
-    <div class="govuk-grid-column-one-third govuk-!-margin-top-5">
-      <!--<div class="govuk-top-border govuk-border-bottom">
-        <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
-          <%= t('actions.filters') %>
-        </p>
+    </section>
+  </div>
+  <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
+    <!--<div class="govuk-top-border govuk-border-bottom">
+      <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
+      <%= t('actions.filters') %>
+      </p>
       </div> -->
       <div class="govuk-top-border govuk-border-bottom">
         <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
-          <%= t('actions.actions') %>
+        <%= t('actions.actions') %>
         </p>
         <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
-          <%= link_to(t('admin.categories.actions.create'),
-                      [:new, :admin, :category],
-                      class: %w[govuk-!-margin-bottom-1]
-                     ) if valid_action?(:new) && show_action?(:new, Category.new) %>
+        <%= link_to(t('admin.categories.actions.create'),
+                    [:new, :admin, :category],
+                    class: %w[govuk-!-margin-bottom-1]
+                   ) if valid_action?(:new) && show_action?(:new, Category.new) %>
         </p>
         <!-- <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
           <%= link_to(t('admin.concepts.actions.create'),
                       [:new, :admin, :concept],
                       class: %w[govuk-!-margin-bottom-1]
                      ) if valid_action?(:new) && show_action?(:new, Concept.new) %>
-        </p> -->
+                   </p> -->
       </div>
       <div>
         <div>
           <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
-            <%= t('actions.change_log') %>
+          <%= t('actions.change_log') %>
           </p>
         </div>
         <div>
@@ -74,13 +75,12 @@
         </div>
         <div>
           <button type="submit" class="govuk-button" id="confirm-changes"
-                  data-confirm-changes data-validate="#changes-approved"><%= t('forms.confirm') %></button>
+                                                     data-confirm-changes data-validate="#changes-approved"><%= t('forms.confirm') %></button>
           <button type="submit" class="govuk-button govuk-button--secondary" id="cancel-changes"
-                  data-cancel-changes><%= t('forms.cancel') %></button>
+                                                                             data-cancel-changes><%= t('forms.cancel') %></button>
         </div>
       </div>
-    </div>
   </div>
-</section>
+</div>
 
 <%= javascript_pack_tag 'nest' %>

--- a/app/views/admin/categories/tree.html.erb
+++ b/app/views/admin/categories/tree.html.erb
@@ -41,6 +41,12 @@
             <%= t('admin.categories.actions.expand_all') %>
           </label>
         </div>
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="expand-concepts" name="expand-concepts" type="checkbox" required="true">
+          <label class="govuk-label govuk-checkboxes__label govuk-!-margin-left-5 govuk-!-padding-top-0" for="expand-concepts">
+            <%= t('admin.concepts.actions.expand_all') %>
+          </label>
+        </div>
       </div>
     </div>
     <div class="govuk-border-bottom">
@@ -53,12 +59,12 @@
                     class: %w[govuk-!-margin-bottom-1]
                    ) if valid_action?(:new) && show_action?(:new, Category.new) %>
       </p>
-      <!-- <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
+      <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
         <%= link_to(t('admin.concepts.actions.create'),
                     [:new, :admin, :concept],
                     class: %w[govuk-!-margin-bottom-1]
                    ) if valid_action?(:new) && show_action?(:new, Concept.new) %>
-                 </p> -->
+      </p>
     </div>
     <div>
       <div>

--- a/app/views/admin/categories/tree.html.erb
+++ b/app/views/admin/categories/tree.html.erb
@@ -11,7 +11,7 @@
   <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0">
     <header class="main-content__header govuk-!-padding-left-0 govuk-!-border-0" role="banner">
       <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-        <h1 class="govuk-heading-l govuk-!-margin-top-2 govuk-!-margin-bottom-5" id="page-title">
+        <h1 class="govuk-heading-l govuk-!-margin-top-2 govuk-!-margin-bottom-3" id="page-title">
           <%= content_for(:title) %>
         </h1>
       </div>
@@ -20,6 +20,10 @@
     <section id="nestable" class="main-content__body main-content__body--flush">
       <% if @categories.present? %>
         <div id="tree_nodes" class="dd" data-update-path="<%= sort_admin_categories_path %>">
+          <div class="legend govuk-!-margin-bottom-2 govuk-!-font-size-16">
+            <span class="legend-entry"><span class="legend-icon legend-icon-grey">&nbsp;</span>Categories</span>
+            <span class="legend-entry"><span class="legend-icon legend-icon-yellow">&nbsp;</span>Concepts</span>
+          </div>
           <ol id="categories" class="list-group nested-sortable dd-list">
             <%= nested_tree_nodes @categories %>
           </ol>

--- a/app/views/admin/categories/tree.html.erb
+++ b/app/views/admin/categories/tree.html.erb
@@ -30,56 +30,64 @@
     </section>
   </div>
   <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
-    <!--<div class="govuk-top-border govuk-border-bottom">
+    <div class="govuk-top-border govuk-border-bottom">
       <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
-      <%= t('actions.filters') %>
+        <%= t('actions.filters') %>
       </p>
-      </div> -->
-      <div class="govuk-top-border govuk-border-bottom">
-        <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
+      <div class="govuk-form-group govuk-checkboxes govuk-checkboxes--small">
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="expand-categories" name="expand-categories" type="checkbox" required="true">
+          <label class="govuk-label govuk-checkboxes__label govuk-!-margin-left-5 govuk-!-padding-top-0" for="expand-categories">
+            <%= t('admin.categories.actions.expand_all') %>
+          </label>
+        </div>
+      </div>
+    </div>
+    <div class="govuk-border-bottom">
+      <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
         <%= t('actions.actions') %>
-        </p>
-        <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
+      </p>
+      <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
         <%= link_to(t('admin.categories.actions.create'),
                     [:new, :admin, :category],
                     class: %w[govuk-!-margin-bottom-1]
                    ) if valid_action?(:new) && show_action?(:new, Category.new) %>
+      </p>
+      <!-- <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
+        <%= link_to(t('admin.concepts.actions.create'),
+                    [:new, :admin, :concept],
+                    class: %w[govuk-!-margin-bottom-1]
+                   ) if valid_action?(:new) && show_action?(:new, Concept.new) %>
+                 </p> -->
+    </div>
+    <div>
+      <div>
+        <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
+        <%= t('actions.change_log') %>
         </p>
-        <!-- <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
-          <%= link_to(t('admin.concepts.actions.create'),
-                      [:new, :admin, :concept],
-                      class: %w[govuk-!-margin-bottom-1]
-                     ) if valid_action?(:new) && show_action?(:new, Concept.new) %>
-                   </p> -->
       </div>
       <div>
-        <div>
-          <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
-          <%= t('actions.change_log') %>
-          </p>
-        </div>
-        <div>
-          <ul class="govuk-list govuk-list--bullet changelog" data-changes-log>
-          </ul>
-        </div>
-        <div class="govuk-form-group govuk-checkboxes govuk-checkboxes--small">
-          <span id="confirm-error" class="govuk-error-message" style="display: none">
-            <span class="govuk-visually-hidden">Error:</span> Please confirm that the changes have been reviewed and approved
-          </span>
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="changes-approved" name="changes-approved" type="checkbox" required="true">
-            <label class="govuk-label govuk-checkboxes__label govuk-!-margin-left-5 govuk-!-padding-top-0" for="organisation">
-              <%= t('forms.changes_approved') %>
-            </label>
-          </div>
-        </div>
-        <div>
-          <button type="submit" class="govuk-button" id="confirm-changes"
-                                                     data-confirm-changes data-validate="#changes-approved"><%= t('forms.confirm') %></button>
-          <button type="submit" class="govuk-button govuk-button--secondary" id="cancel-changes"
-                                                                             data-cancel-changes><%= t('forms.cancel') %></button>
+        <ul class="govuk-list govuk-list--bullet changelog" data-changes-log>
+        </ul>
+      </div>
+      <div class="govuk-form-group govuk-checkboxes govuk-checkboxes--small">
+        <span id="confirm-error" class="govuk-error-message" style="display: none">
+          <span class="govuk-visually-hidden">Error:</span> Please confirm that the changes have been reviewed and approved
+        </span>
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="changes-approved" name="changes-approved" type="checkbox" required="true">
+          <label class="govuk-label govuk-checkboxes__label govuk-!-margin-left-5 govuk-!-padding-top-0" for="organisation">
+            <%= t('forms.changes_approved') %>
+          </label>
         </div>
       </div>
+      <div>
+        <button type="submit" class="govuk-button" id="confirm-changes"
+                                                   data-confirm-changes data-validate="#changes-approved"><%= t('forms.confirm') %></button>
+        <button type="submit" class="govuk-button govuk-button--secondary" id="cancel-changes"
+                                                                           data-cancel-changes><%= t('forms.cancel') %></button>
+      </div>
+    </div>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,9 +154,11 @@ en:
     categories:
       actions:
         create: Create a new category
+        expand_all: Expand all categories
     concepts:
       actions:
         create: Create a new concept
+        expand_all: Expand all concepts
     data_elements:
       title: Data Items
       reindex:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -232,3 +232,8 @@ en:
   date:
     formats:
       npd: "%d %B %Y"
+      npd_long: "%A, %d %B %Y %H:%M:%S"
+
+  time:
+    formats:
+      npd_long: "%A, %d %B %Y %H:%M:%S"

--- a/spec/system/admin/categories_sort_spec.rb
+++ b/spec/system/admin/categories_sort_spec.rb
@@ -20,13 +20,12 @@ RSpec.describe 'Categories Import', type: :system do
     click_on('Log in')
   end
 
-  it 'Will show the sort page' do
+  it 'Will show the sort page', javascript: true do
     visit 'admin/categories/tree'
 
     expect(page).to have_text('Sort Categories')
     Category.roots.each do |root|
       expect(page).to have_text(root.name)
     end
-    expect(page).to have_css('li div.dd3-content + ol.dd-list')
   end
 end

--- a/spec/system/admin/concept_show_spec.rb
+++ b/spec/system/admin/concept_show_spec.rb
@@ -20,14 +20,4 @@ RSpec.describe 'Admin Concepts Show', type: :system do
     fill_in('admin_user_password', with: password)
     click_on('Log in')
   end
-
-  it 'Will have the breadcrumbs' do
-    concept = Concept.first
-    breadcrumbs = ['Home', concept.category.ancestors.map(&:name).reverse, concept.category.name]
-                  .flatten
-                  .join("\n")
-
-    visit "/admin/concepts/#{concept.id}"
-    expect(page).to have_text(breadcrumbs)
-  end
 end


### PR DESCRIPTION
# Admin area: redesign 'Sort Categories' function - additional info, collapse and concepts

## Development

* Add functionality to 'expand' and 'collapse' the categories and concepts.
* in the 'Filters' section, unticking either of the options collapses the categories or concepts;
* whether the filters are checked are unchecked, users can manually expand or collapse individual categories and concepts
* Add additional elements to the horizontal Categories bars
  * the number of 'children' (categories, concepts)
  * An 'Edit' link - clicking the 'Edit' link allows the user to change the name and description of the category
  * a 'View detail' link, to show description and additional data.
* Add horizontal Concepts bars that show
  * the name of the concept;
  * the number 'children' (data items)
  * An 'Edit' link -clicking the 'Edit' link allows the user to change the name and description of the concept
  * A 'View detail' link, to show description and additional data

## Screenshots

### Initial situation

<img width="704" alt="676_01_closed" src="https://user-images.githubusercontent.com/2742327/103914297-839f3b80-5101-11eb-95c2-1b52bf27aeee.png">

### Open categories

![676_02_open_cats](https://user-images.githubusercontent.com/2742327/103914744-366f9980-5102-11eb-8085-8599afbd7fb5.jpg)

### Open concepts

![676_03_open_concepts](https://user-images.githubusercontent.com/2742327/103914948-7171cd00-5102-11eb-9bdb-c003a8957354.jpg)

### Log

<img width="995" alt="676_04_log" src="https://user-images.githubusercontent.com/2742327/103915069-9d8d4e00-5102-11eb-89e8-76861ebadd2c.png">
