### PR TITLE
Dev #676 - fix issues after UAT

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -50,7 +50,7 @@ module Admin
 
     def tree
       custom_breadcrumbs_for(admin: true,
-                             leaf: 'Categories')
+                             leaf: 'Sort Categories and Concepts')
 
       # @categories = Category.includes(concepts: :data_elements }).arrange(order: :position)
       @categories = Category.roots.includes(concepts: :data_elements)
@@ -167,7 +167,7 @@ module Admin
 
     def generate_breadcrumbs
       custom_breadcrumbs_for(admin: true,
-                             steps: [{ name: 'Categories', path: admin_categories_path }],
+                             steps: [{ name: 'Sort Categories and Concepts', path: admin_categories_path }],
                              leaf: params[:id].present? ? requested_resource.name : params[:action].titleize)
     end
   end

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -67,9 +67,9 @@ module Admin
         end
 
         if concepts.any?
-          category = Category.find(params[:parent])
-          category.concept_ids = concepts.map { |id| id.gsub(/^concept-/, '') }
-          category.save!
+          Concept
+            .where(id: concepts.map { |id| id.gsub(/^concept-/, '') })
+            .update_all(category_id: params[:parent])
         end
 
         message = "<strong>#{I18n.t('admin.actions.nestable.success')}!</strong>"

--- a/app/controllers/admin/concepts_controller.rb
+++ b/app/controllers/admin/concepts_controller.rb
@@ -67,7 +67,7 @@ module Admin
 
     def generate_breadcrumbs
       custom_breadcrumbs_for(admin: true,
-                             steps: [{ name: 'Concepts', path: admin_categories_path }],
+                             steps: [{ name: 'Sort Categories and Concepts', path: admin_categories_path }],
                              leaf: params[:id].present? ? requested_resource.name : params[:action].titleize)
     end
   end

--- a/app/helpers/nestable_helper.rb
+++ b/app/helpers/nestable_helper.rb
@@ -20,7 +20,7 @@ module NestableHelper
             content += content_tag :div, class: %w[dd-extras] do
               extras = children_count(category)
               extras += link_to 'Edit', edit_admin_category_path(category.id), class: %w[dd-link]
-              extras += link_to 'View detail', '#', class: %w[dd-link view-detail]
+              extras += link_to 'View details', '#', class: %w[dd-link view-detail]
               extras
             end
             content
@@ -51,7 +51,7 @@ module NestableHelper
             content += content_tag :div, class: %w[dd-extras] do
               extras = content_tag :span, "#{concept.data_elements.count} data items", class: %w[dd-count]
               extras += link_to 'Edit', edit_admin_concept_path(concept.id), class: %w[dd-link]
-              extras += link_to 'View detail', '#', class: %w[dd-link view-detail]
+              extras += link_to 'View details', '#', class: %w[dd-link view-detail]
               extras
             end
             content

--- a/app/javascript/src/nest.js
+++ b/app/javascript/src/nest.js
@@ -144,6 +144,7 @@ function initializeCommitChanges() {
       localStorage.setItem('sequence', '0')
       localStorage.removeItem('sortLog')
       $('[data-changes-log]').empty();
+      $('#changes-approved')[0].checked = false;
     }
   });
 }

--- a/app/javascript/src/nest.js
+++ b/app/javascript/src/nest.js
@@ -152,7 +152,7 @@ function initializeViewDetails() {
   $('.view-detail').click(function (event) {
     event.preventDefault();
     const link = $(event.currentTarget);
-    const details = link.parents('.dd3-content').siblings('.dd-details');
+    const details = link.parents('.dd-content').siblings('.dd-details');
     if (details.hasClass('hidden')) {
       details.removeClass('hidden');
       link.text('Hide details');

--- a/app/views/admin/application/new.html.erb
+++ b/app/views/admin/application/new.html.erb
@@ -1,0 +1,33 @@
+<%#
+# New
+
+This view is the template for the "new resource" page.
+It displays a header, and then renders the `_form` partial
+to do the heavy lifting.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to help display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<% content_for(:title) do %>
+  <%= t(
+    'administrate.actions.new_resource',
+    name: display_resource_name(page.resource_name).titleize
+  ) %>
+<% end %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+</header>
+
+<section class="main-content__body">
+  <%= render 'form', page: page %>
+</section>

--- a/app/views/admin/application/show.html.erb
+++ b/app/views/admin/application/show.html.erb
@@ -1,0 +1,49 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { t('administrate.actions.show_resource', name: page.page_title) } %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t('actions.edit', name: page.resource.class.name),
+      [:edit, namespace, page.resource],
+      class: 'govuk-button',
+    ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |attribute| %>
+      <dt class="attribute-label" id="<%= attribute.name %>">
+      <%= t(
+        "helpers.label.#{resource_name}.#{attribute.name}",
+        default: attribute.name.titleize,
+      ) %>
+      </dt>
+
+      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+          ><%= render_field attribute, page: page %></dd>
+    <% end %>
+  </dl>
+</section>

--- a/app/views/admin/categories/tree.html.erb
+++ b/app/views/admin/categories/tree.html.erb
@@ -3,7 +3,10 @@
 <% end %>
 
 <% content_for(:additional_tags) do %>
+  <%= stylesheet_pack_tag 'loader' %>
   <%= stylesheet_pack_tag 'nest' %>
+  <%= javascript_pack_tag 'loader' %>
+  <%= javascript_pack_tag 'nest' %>
 <% end %>
 
 
@@ -24,9 +27,12 @@
             <span class="legend-entry"><span class="legend-icon legend-icon-grey">&nbsp;</span>Categories</span>
             <span class="legend-entry"><span class="legend-icon legend-icon-yellow">&nbsp;</span>Concepts</span>
           </div>
+          <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
+
           <ol id="categories" class="list-group nested-sortable dd-list">
             <%= nested_tree_nodes @categories %>
           </ol>
+
         </div>
       <% else %>
         <h3>There are currently no categories.</h3>
@@ -100,5 +106,3 @@
     </div>
   </div>
 </div>
-
-<%= javascript_pack_tag 'nest' %>

--- a/app/views/admin/categories/tree.html.erb
+++ b/app/views/admin/categories/tree.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) do %>
-  Sort Categories
+  Sort Categories and Concepts
 <% end %>
 
 <% content_for(:additional_tags) do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
     filter: Filter
     change_log: Change log
     destroy: "Delete %{name}"
+    destroy: "Edit %{name}"
   beta_banner:
     text: This is a new service – we are improving how the metadata from the NPD Data Tables can be displayed and therefore the content might change. Your %{link} will help us to improve it.
     link: feedback


### PR DESCRIPTION
# Fix issues

## Development:

Fix the issues found during the live UAT:

* View details for concepts wasn't working, now fixed.
* Some links and headers were still reading 'Categories' instead of 'Sort Categories and Concepts', now fixed.
* Removed 'Back' button from 'new category' and 'new concept' pages.
* Fix color schemes with the 'Edit' button in the category and concept details (was blue on blue, unreadable, now it's the GovUK standard white on green button).
* Fix an issue that was making the 'move concept' action fail.