### PR TITLE
Dev #697 - First step: replace admin landing page

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -8,6 +8,7 @@
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
+    layout 'admin/side_menu'
     before_action :authenticate_admin_user!
 
     helper AdministrateMenuHelper

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -2,10 +2,10 @@
 
 module Admin
   class CategoriesController < Admin::ApplicationController
-    layout :layout_by_resource
-
     helper NestableHelper
     include BreadcrumbBuilder
+
+    layout :layout_by_resource
 
     before_action :generate_breadcrumbs, only: %i[new create show edit update]
 
@@ -79,7 +79,7 @@ module Admin
     def import
       trim_inf_arch_uploads(count: 10)
 
-      render :import, layout: 'admin/application', locals: { success: nil, errors: [] }
+      render :import, layout: layout_by_resource, locals: { success: nil, errors: [] }
     end
 
     def preprocess
@@ -155,9 +155,9 @@ module Admin
 
     def layout_by_resource
       if %w[index new create show edit update].include?(params[:action])
-        'admin/wide'
-      else
         'admin/application'
+      else
+        'admin/side_menu'
       end
     end
 

--- a/app/controllers/admin/concepts_controller.rb
+++ b/app/controllers/admin/concepts_controller.rb
@@ -51,9 +51,9 @@ module Admin
 
     def layout_by_resource
       if %w[new create show edit update].include?(params[:action])
-        'admin/wide'
-      else
         'admin/application'
+      else
+        'admin/side_menu'
       end
     end
 

--- a/app/controllers/admin/data_elements_controller.rb
+++ b/app/controllers/admin/data_elements_controller.rb
@@ -59,19 +59,19 @@ module Admin
     # functionality completely.
     # ==========================================================================
     def reindex
-      render :reindex, layout: 'admin/application', locals: { success: nil, errors: [] }
+      render :reindex, layout: layout_by_resource, locals: { success: nil, errors: [] }
     end
 
     def do_reindex
       DataElement.rebuild_pg_search_documents
 
       render :reindex,
-             layout: 'admin/application',
+             layout: layout_by_resource,
              locals: { success: true, errors: [] }
     rescue StandardError => e
       Rails.logger.error(e)
       render :reindex,
-             layout: 'admin/application',
+             layout: layout_by_resource,
              locals: { success: false, errors: ['There has been an error while reindexing the data items'] }
     end
 
@@ -93,9 +93,9 @@ module Admin
 
     def layout_by_resource
       if orphaned_actions?
-        'admin/wide'
-      else
         'admin/application'
+      else
+        'admin/side_menu'
       end
     end
   end

--- a/app/controllers/admin/home_controller.rb
+++ b/app/controllers/admin/home_controller.rb
@@ -1,0 +1,11 @@
+module Admin
+  class HomeController < Admin::ApplicationController
+    include BreadcrumbBuilder
+
+    layout 'admin/application'
+
+    def index
+      custom_breadcrumbs_for(admin: true)
+    end
+  end
+end

--- a/app/controllers/admin/import_datasets_controller.rb
+++ b/app/controllers/admin/import_datasets_controller.rb
@@ -2,15 +2,14 @@
 
 module Admin
   class ImportDatasetsController < Admin::ApplicationController
-    layout 'admin/wide'
-
     include BreadcrumbBuilder
+
+    layout 'admin/application'
 
     def import
       trim_data_table_uploads(count: 5)
 
       custom_breadcrumbs_for(admin: true,
-                             steps: [{ name: 'Manage dataset import and export', path: admin_uploads_path }],
                              leaf: 'Import datasets')
 
       render :import_start, locals: { success: nil, error: '' }

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -1,0 +1,97 @@
+<% content_for(:title) do %>
+  <%= t('admin.home.title') %>
+<% end %>
+
+<header class="main-content__header govuk-!-padding-left-0 govuk-!-border-0" role="banner">
+  <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
+    <h1 class="govuk-heading-l govuk-!-margin-top-5 govuk-!-margin-bottom-5" id="page-title">
+      <%= content_for(:title) %>
+    </h1>
+  </div>
+</header>
+
+<section class="main-content__body main-content__body--flush">
+  <div class="govuk-grid-row govuk-!-margin-bottom-2">
+    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
+        <%= t('admin.home.menu.categories.title') %>
+      </h2>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <%= link_to t('admin.home.menu.categories.links.sort'), %w[admin categories] %>
+        </li>
+        <li>
+          <%= link_to t('admin.home.menu.categories.links.childless_categories'),
+            %w[childless admin categories] %>
+        </li>
+        <li>
+          <%= link_to t('admin.home.menu.categories.links.childless_concepts'),
+            %w[childless admin concepts] %>
+        </li>
+      </ul>
+    </div>
+    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
+        <%= t('admin.home.menu.data_items.title') %>
+      </h2>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <%= link_to t('admin.home.menu.data_items.links.all'), %w[admin data_elements] %>
+        </li>
+        <li>
+          <%= link_to t('admin.home.menu.data_items.links.orphaned'),
+            %w[orphaned admin data_elements] %>
+        </li>
+      </ul>
+    </div>
+    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
+        <%= t('admin.home.menu.datasets.title') %>
+      </h2>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <%= link_to t('admin.home.menu.datasets.links.all'), %w[admin datasets] %>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
+        <%= t('admin.home.menu.import_export.title') %>
+      </h2>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <%= link_to t('admin.home.menu.import_export.links.recent'), %w[admin uploads] %>
+        </li>
+        <li>
+          <%= link_to t('admin.home.menu.import_export.links.import_data_tables'),
+            %w[import admin import_datasets] %>
+        </li>
+        <li>
+          <%= link_to t('admin.home.menu.import_export.links.import_ia_file'),
+            %w[import admin categories] %>
+        </li>
+        <li>
+          <%= link_to t('admin.home.menu.import_export.links.export_ia_file'),
+            %w[export admin categories] %>
+        </li>
+      </ul>
+    </div>
+    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
+        <%= t('admin.home.menu.admin.title') %>
+      </h2>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <%= link_to t('admin.home.menu.admin.links.users'), %w[admin admin_users] %>
+        </li>
+        <li>
+          <%= link_to t('admin.home.menu.admin.links.search_index'),
+            %w[reindex admin data_elements] %>
+        </li>
+      </ul>
+    </div>
+    <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2"></div>
+  </div>
+</div>

--- a/app/views/layouts/admin/application.html.erb
+++ b/app/views/layouts/admin/application.html.erb
@@ -8,10 +8,13 @@
       <%= content_for(:title) || 'Dashboard' %> -
       <%= Rails.application.class.parent_name.titlecase %>
     </title>
+    <%= javascript_pack_tag 'check_all' %>
+    <%= javascript_pack_tag 'validate-forms' %>
+    <%= javascript_pack_tag 'save_to_local_storage' %>
     <%= javascript_pack_tag 'administrate', 'data-turbolinks-track': 'reload' %>
-    <%= stylesheet_pack_tag 'administrate' %>
-    <%= stylesheet_pack_tag 'application' %>
     <%= render 'administrate/application/stylesheet' %>
+    <%= stylesheet_pack_tag 'application' %>
+    <%= stylesheet_pack_tag 'selectize_govuk' %>
     <%= csrf_meta_tags %>
     <%= yield :additional_tags %>
     <meta name="turbolinks-root" content="/admin">
@@ -24,11 +27,7 @@
     <div class="govuk-width-container">
       <%= render 'shared/staging' unless Rails.env.production? %>
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-quarter">
-          <%= render 'layouts/admin/navigation' %>
-        </div>
-        <div class="govuk-grid-column-three-quarters">
-          <%= render 'administrate/application/flashes' %>
+        <div class="govuk-grid-column-full">
           <%= render "shared/breadcrumbs" %>
           <%= yield %>
         </div>

--- a/app/views/layouts/admin/side_menu.html.erb
+++ b/app/views/layouts/admin/side_menu.html.erb
@@ -8,13 +8,10 @@
       <%= content_for(:title) || 'Dashboard' %> -
       <%= Rails.application.class.parent_name.titlecase %>
     </title>
-    <%= javascript_pack_tag 'check_all' %>
-    <%= javascript_pack_tag 'validate-forms' %>
-    <%= javascript_pack_tag 'save_to_local_storage' %>
     <%= javascript_pack_tag 'administrate', 'data-turbolinks-track': 'reload' %>
-    <%= render 'administrate/application/stylesheet' %>
+    <%= stylesheet_pack_tag 'administrate' %>
     <%= stylesheet_pack_tag 'application' %>
-    <%= stylesheet_pack_tag 'selectize_govuk' %>
+    <%= render 'administrate/application/stylesheet' %>
     <%= csrf_meta_tags %>
     <%= yield :additional_tags %>
     <meta name="turbolinks-root" content="/admin">
@@ -27,7 +24,11 @@
     <div class="govuk-width-container">
       <%= render 'shared/staging' unless Rails.env.production? %>
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
+        <div class="govuk-grid-column-one-quarter">
+          <%= render 'layouts/admin/navigation' %>
+        </div>
+        <div class="govuk-grid-column-three-quarters">
+          <%= render 'administrate/application/flashes' %>
           <%= render "shared/breadcrumbs" %>
           <%= yield %>
         </div>

--- a/config/administrate_menu.yml
+++ b/config/administrate_menu.yml
@@ -1,4 +1,10 @@
 default: &default
+  home:
+    main:
+      name: Home
+      url_params:
+        - admin
+        - root
   categories:
     main:
       name: Sort Categories and Concepts

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,6 +153,36 @@ en:
       nestable:
         success: Tree updated! Reloading the page to reflect your changes.
         error: Error while updating the tree
+    home:
+      title: '"Find and Explore" NPD Admin tool'
+      menu:
+        categories:
+          title: Categories and concepts
+          links:
+            sort: Sort categories and concepts
+            childless_categories: Childless categories
+            childless_concepts: Childless concepts
+        data_items:
+          title: Data items
+          links:
+            all: All data items
+            orphaned: Orphaned data items
+        datasets:
+          title: Datasets
+          links:
+            all: All datasets
+        import_export:
+          title: Manage uploads and downloads
+          links:
+            recent: Recent uploads
+            import_data_tables: Import data tables
+            import_ia_file: Import categories and concepts backup file
+            export_ia_file: Create categories and concepts backup file
+        admin:
+          title: Admin tasks
+          links:
+            users: Manage admin users
+            search_index: Start search index refresh
     categories:
       actions:
         create: Create a new category

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,7 @@ Rails.application.routes.draw do
     end
     resources :uploads, only: %i[index]
 
-    root to: 'admin_users#index'
+    root to: 'home#index'
   end
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
# Admin area: improve overall look and feel and usability of the admin user landing page

## Development

For this first step, the various links still point to the existing versions of the pages.

During the work on the following tickets, each destination page will be replaced by their updated counterpart and the left hand menu will disappear, however, for this first test a new "home" link has been added to the left hand menu to maintain navigation.

## Screenshots

### New landing page

<img width="772" alt="Screen Shot 2021-03-18 at 19 43 39" src="https://user-images.githubusercontent.com/2742327/111689135-8c0fa300-8823-11eb-8c4a-10cb1af06cf3.png">

### Temporarily added link to the new landing page to the side menu

<img width="757" alt="Screen Shot 2021-03-18 at 19 43 59" src="https://user-images.githubusercontent.com/2742327/111689298-c2e5b900-8823-11eb-82ae-6a18e87af7b9.png">
