### PR TITLE
Dev #702 - Admin Area: redesign 'All datasets' pages

### DIFF
--- a/app/controllers/admin/datasets_controller.rb
+++ b/app/controllers/admin/datasets_controller.rb
@@ -2,6 +2,10 @@
 
 module Admin
   class DatasetsController < Admin::ApplicationController
+    layout :layout_by_resource
+
+    before_action :generate_breadcrumbs, only: %i[index]
+
     def destroy
       requested_resource.data_table_tabs.destroy_all
       requested_resource
@@ -15,6 +19,21 @@ module Admin
         flash[:error] = requested_resource.errors.full_messages.join('<br/>')
       end
       redirect_to action: :index
+    end
+
+  private
+
+    def layout_by_resource
+      if %w[index].include?(params[:action])
+        'admin/application'
+      else
+        'admin/side_menu'
+      end
+    end
+
+    def generate_breadcrumbs
+      custom_breadcrumbs_for(admin: true,
+                             leaf: params[:id].present? ? requested_resource.name : I18n.translate('admin.datasets.title'))
     end
   end
 end

--- a/app/controllers/admin/datasets_controller.rb
+++ b/app/controllers/admin/datasets_controller.rb
@@ -5,6 +5,7 @@ module Admin
     layout :layout_by_resource
 
     before_action :generate_breadcrumbs, only: %i[index]
+    before_action :generate_back_breadcrumbs, only: %i[show]
 
     def destroy
       requested_resource.data_table_tabs.destroy_all
@@ -24,7 +25,7 @@ module Admin
   private
 
     def layout_by_resource
-      if %w[index].include?(params[:action])
+      if %w[index show].include?(params[:action])
         'admin/application'
       else
         'admin/side_menu'

--- a/app/controllers/admin/datasets_controller.rb
+++ b/app/controllers/admin/datasets_controller.rb
@@ -2,10 +2,10 @@
 
 module Admin
   class DatasetsController < Admin::ApplicationController
-    layout :layout_by_resource
+    layout 'admin/application'
 
     before_action :generate_breadcrumbs, only: %i[index]
-    before_action :generate_back_breadcrumbs, only: %i[show]
+    before_action :generate_back_breadcrumbs, only: %i[show new edit create update]
 
     def destroy
       requested_resource.data_table_tabs.destroy_all
@@ -23,14 +23,6 @@ module Admin
     end
 
   private
-
-    def layout_by_resource
-      if %w[index show].include?(params[:action])
-        'admin/application'
-      else
-        'admin/side_menu'
-      end
-    end
 
     def generate_breadcrumbs
       custom_breadcrumbs_for(admin: true,

--- a/app/javascript/src/_govuk-overrides.scss
+++ b/app/javascript/src/_govuk-overrides.scss
@@ -158,9 +158,54 @@
   background-color: govuk-colour('light-grey');
 }
 
+.govuk-\!-width-one-fifth {
+  width: 20% !important;
+}
+
+.govuk-\!-width-two-fifths {
+  width: 40% !important;
+}
+
+.govuk-\!-width-three-fifths {
+  width: 60% !important;
+}
+
+.govuk-\!-width-four-fifths {
+  width: 80% !important;
+}
+
+.govuk-\!-width-five-fifths {
+  width: 100% !important;
+}
+
+.govuk-\!-width-one-sixth {
+  width: 16% !important;
+}
+
+.govuk-\!-width-two-sixths {
+  width: 33% !important;
+}
+
+.govuk-\!-width-three-sixths {
+  width: 49% !important;
+}
+
+.govuk-\!-width-four-sixths {
+  width: 66% !important;
+}
+
+.govuk-\!-width-five-sixths {
+  width: 83% !important;
+}
+
+.govuk-\!-width-six-sixths {
+  width: 100% !important;
+}
+
 .govuk-\!-width-one-tenth {
   width: 10% !important;
 }
+
 
 .govuk-\!-width-two-tenths {
   width: 20% !important;
@@ -192,6 +237,10 @@
 
 .govuk-\!-width-nine-tenths {
   width: 90% !important;
+}
+
+.govuk-\!-width-ten-tenths {
+  width: 100% !important;
 }
 
 .govuk-border-bottom {

--- a/app/views/admin/application/_form.html.erb
+++ b/app/views/admin/application/_form.html.erb
@@ -1,19 +1,3 @@
-<%#
-# Form Partial
-
-This partial is rendered on a resource's `new` and `edit` pages,
-and renders all form fields for a resource's editable attributes.
-
-## Local variables:
-
-- `page`:
-  An instance of [Administrate::Page::Form][1].
-  Contains helper methods to display a form,
-  and knows which attributes should be displayed in the resource's form.
-
-[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
-%>
-
 <%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
   <% if page.resource.errors.any? %>
     <div id="error_explanation">

--- a/app/views/admin/application/delete_confirmation.html.erb
+++ b/app/views/admin/application/delete_confirmation.html.erb
@@ -9,7 +9,7 @@
     <section class="main-content__body main-content__body--flush">
       <div class="govuk-grid-row govuk-!-margin-top-3 govuk-!-padding-bottom-5">
         <div class="govuk-grid-column-full">
-          <%= form_with url: :admin_category, method: :delete, local: true,
+          <%= form_with url: [:admin, page.resource], method: :delete, local: true,
             id: 'confirm-delete-form', data: { js_validate: true } do |f| -%>
             <div id="form-group-delete" class="govuk-form-group">
 

--- a/app/views/admin/application/new.html.erb
+++ b/app/views/admin/application/new.html.erb
@@ -1,20 +1,3 @@
-<%#
-# New
-
-This view is the template for the "new resource" page.
-It displays a header, and then renders the `_form` partial
-to do the heavy lifting.
-
-## Local variables:
-
-- `page`:
-  An instance of [Administrate::Page::Form][1].
-  Contains helper methods to help display a form,
-  and knows which attributes should be displayed in the resource's form.
-
-[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
-%>
-
 <% content_for(:title) do %>
   <%= t(
     'administrate.actions.new_resource',

--- a/app/views/admin/categories/_collection.html.erb
+++ b/app/views/admin/categories/_collection.html.erb
@@ -1,23 +1,3 @@
-<%#
-# Collection
-
-This partial is used on the `index` and `show` pages
-to display a collection of resources in an HTML table.
-
-## Local variables:
-
-- `collection_presenter`:
-  An instance of [Administrate::Page::Collection][1].
-  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
-  the columns displayed in the table
-- `resources`:
-  An ActiveModel::Relation collection of resources to be displayed in the table.
-  By default, the number of resources is limited by pagination
-  or by a hard limit to prevent excessive page load times
-
-[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
-%>
-
 <table aria-labelledby="<%= table_title %>" class="govuk-!-margin-top-0 govuk-!-margin-bottom-5">
   <tbody>
     <% resources.each do |resource| %>

--- a/app/views/admin/categories/show.html.erb
+++ b/app/views/admin/categories/show.html.erb
@@ -16,7 +16,7 @@
                 <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
                   <%= t('admin.categories.id') %>
                 </td>
-                <td colspan="3" data-label="Id" class="govuk-table__cell govuk-body">
+                <td colspan="3" data-label="<%= t('admin.categories.id') %>" class="govuk-table__cell govuk-body">
                   <%= resource.id %>
                 </td>
               </tr>
@@ -24,7 +24,7 @@
                 <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
                   <%= t('admin.categories.description') %>
                 </td>
-                <td colspan="3" data-label="Description" class="govuk-table__cell govuk-body">
+                <td colspan="3" data-label="<%= t('admin.categories.description') %>" class="govuk-table__cell govuk-body">
                   <%= resource.description %>
                 </td>
               </tr>
@@ -32,7 +32,7 @@
                 <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
                   <%= t('admin.categories.parent') %>
                 </td>
-                <td colspan="3" data-label="Parent" class="govuk-table__cell govuk-body">
+                <td colspan="3" data-label="<%= t('admin.categories.parent') %>" class="govuk-table__cell govuk-body">
                   <% if resource.parent.present? -%>
                     <%= link_to resource.parent.name, polymorphic_path([namespace, resource.parent]),
                       class: %w[govuk-!-padding-right-2] %>
@@ -45,7 +45,7 @@
                 <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
                   <%= t('admin.categories.concepts') %>
                 </td>
-                <td colspan="3" data-label="Concepts" class="govuk-table__cell govuk-body">
+                <td colspan="3" data-label="<%= t('admin.categories.concepts') %>" class="govuk-table__cell govuk-body">
                   <%= resource.concepts.any? ? resource.concepts.count : 'None' %>
                 </td>
               </tr>
@@ -53,7 +53,7 @@
                 <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
                   <%= t('admin.categories.child_categories') %>
                 </td>
-                <td colspan="3" data-label="Child Categories" class="govuk-table__cell govuk-body">
+                <td colspan="3" data-label="<%= t('admin.categories.child_categories') %>" class="govuk-table__cell govuk-body">
                   <%= resource.children.any? ? resource.children.count : 'None' %>
                 </td>
               </tr>
@@ -61,7 +61,7 @@
                 <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
                   <%= t('admin.categories.created_at') %>
                 </td>
-                <td colspan="3" data-label="Created At" class="govuk-table__cell govuk-body">
+                <td colspan="3" data-label="<%= t('admin.categories.created_at') %>" class="govuk-table__cell govuk-body">
                   <%= I18n.localize(resource.created_at.in_time_zone('GB'), format: :default ) %>
                 </td>
               </tr>
@@ -69,7 +69,7 @@
                 <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
                   <%= t('admin.categories.updated_at') %>
                 </td>
-                <td colspan="3" data-label="Updated At" class="govuk-table__cell govuk-body">
+                <td colspan="3" data-label="<%= t('admin.categories.updated_at') %>" class="govuk-table__cell govuk-body">
                   <%= I18n.localize(resource.updated_at.in_time_zone('GB'), format: :default ) %>
                 </td>
               </tr>

--- a/app/views/admin/concepts/_resource.html.erb
+++ b/app/views/admin/concepts/_resource.html.erb
@@ -38,7 +38,7 @@
           class: %w[govuk-!-padding-right-2] %>
       <% end %>
       <% if resource.category.present? && valid_action?(:edit, 'category') && show_action?(:edit, 'category') %>
-        <%= link_to t('admin.actions.edit'), [:edit, namespace, resource]%>
+        <%= link_to t('admin.actions.edit'), [:edit, namespace, resource.category]%>
       <% end %>
     </p>
   </td>

--- a/app/views/admin/concepts/edit.html.erb
+++ b/app/views/admin/concepts/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) do %>
-  <%= t('administrate.actions.edit_resource', name: page.page_title) %>
+  <%= t('admin.concepts.actions.edit') %>
 <% end %>
 
 <div class="govuk-grid-row govuk-!-margin-top-0">

--- a/app/views/admin/data_elements/_collection.html.erb
+++ b/app/views/admin/data_elements/_collection.html.erb
@@ -1,7 +1,7 @@
 <table aria-labelledby="<%= table_title %>" class="govuk-!-margin-top-0 govuk-!-margin-bottom-5">
   <tbody>
     <% resources.each do |resource| %>
-      <%= render 'admin/categories/resource', resource: resource, collection_presenter: collection_presenter %>
+      <%= render 'admin/data_elements/resource', resource: resource, collection_presenter: collection_presenter %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/admin/data_elements/_resource.html.erb
+++ b/app/views/admin/data_elements/_resource.html.erb
@@ -1,7 +1,7 @@
 <tr class="govuk-table__row">
   <th colspan="3" class="govuk-table__header govuk-!-padding-left-0" scope="col">
     <h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-5 float-left">
-      <%= resource.name %>
+      <%= resource.unique_alias %>
     </h3>
   </th>
   <td class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-quarter" scope="col">
@@ -10,33 +10,30 @@
         <%= link_to t('admin.actions.view_details'), polymorphic_path([namespace, resource]),
           class: %w[govuk-!-padding-right-2] %>
       <% end %>
-      <% if valid_action?(:edit, collection_presenter.resource_name) && show_action?(:edit, resource) %>
-        <%= link_to t('admin.actions.edit'), [:edit, namespace, resource]%>
-      <% end %>
     </p>
   </td>
 </tr>
 <tr>
   <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-quarter govuk-body govuk-!-font-weight-bold">
-    <%= t('admin.categories.description') %>
+    <%= t('admin.data_elements.dataset') %>
   </td>
-  <td colspan="3" data-label="<%= t('admin.categories.description') %>" class="govuk-table__cell govuk-body">
-    <%= resource.description %>
-  </td>
-</tr>
-<tr>
-  <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-quarter govuk-body govuk-!-font-weight-bold">
-    <%= t('admin.categories.concepts') %>
-  </td>
-  <td colspan="3" data-label="<%= t('admin.categories.concepts') %>" class="govuk-table__cell govuk-body">
-    <%= resource.concepts.count %>
+  <td colspan="3" data-label="<%= t('admin.data_elements.dataset') %>" class="govuk-table__cell govuk-body">
+    <%= resource.dataset %>
   </td>
 </tr>
 <tr>
   <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-quarter govuk-body govuk-!-font-weight-bold">
-    <%= t('admin.categories.child_categories') %>
+    <%= t('admin.data_elements.concept') %>
   </td>
-  <td colspan="3" data-label="<%= t('admin.categories.child_categories') %>" class="govuk-table__cell govuk-body">
-    <%= resource.children.count %>
+  <td colspan="3" data-label="<%= t('admin.data_elements.concept') %>" class="govuk-table__cell govuk-body">
+    <%= resource.concept&.name || 'N/A' %>
+  </td>
+</tr>
+<tr>
+  <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-quarter govuk-body govuk-!-font-weight-bold">
+    <%= t('admin.data_elements.datasets') %>
+  </td>
+  <td colspan="3" data-label="<%= t('admin.data_elements.datasets') %>" class="govuk-table__cell govuk-body">
+    <%= resource.datasets.count %>
   </td>
 </tr>

--- a/app/views/admin/datasets/_collection.html.erb
+++ b/app/views/admin/datasets/_collection.html.erb
@@ -1,0 +1,23 @@
+<table aria-labelledby="<%= table_title %>" class="govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+  <thead>
+    <tr class="govuk-table__row" id="data-elements-header">
+      <th data-label="<%= t('admin.datasets.name') %>" class="govuk-table__header govuk-!-padding-left-0" scope="col">
+        <%= t('admin.datasets.name') %>
+      </th>
+      <th data-label="<%= t('admin.datasets.tab_name') %>" class="govuk-table__header" scope="col">
+        <%= t('admin.datasets.tab_name') %>
+      </th>
+      <th data-label="<%= t('admin.datasets.data_items') %>" class="govuk-table__header govuk-table__cell--no-break" scope="col">
+        <%= t('admin.datasets.data_items') %>
+      </th>
+      <th data-label="<%= t('admin.actions.view_details') %>" class="govuk-table__header govuk-!-padding-right-0 right" scope="col">
+        &nbsp;
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% resources.each do |resource| %>
+      <%= render 'resource', resource: resource, collection_presenter: collection_presenter %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/datasets/_form.html.erb
+++ b/app/views/admin/datasets/_form.html.erb
@@ -1,19 +1,3 @@
-<%#
-# Form Partial
-
-This partial is rendered on a resource's `new` and `edit` pages,
-and renders all form fields for a resource's editable attributes.
-
-## Local variables:
-
-- `page`:
-  An instance of [Administrate::Page::Form][1].
-  Contains helper methods to display a form,
-  and knows which attributes should be displayed in the resource's form.
-
-[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
-%>
-
 <%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
   <% if page.resource.errors.any? %>
     <div id="error_explanation">
@@ -35,13 +19,13 @@ and renders all form fields for a resource's editable attributes.
 
   <% page.attributes.each do |attribute| -%>
     <% next if attribute.attribute == :headers_regex %>
-    <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
+    <div class="field-unit govuk--field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
       <%= render_field attribute, f: f %>
     </div>
   <% end -%>
 
   <% attribute = page.attributes.find { |a| a.attribute == :headers_regex } %>
-  <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
+  <div class="field-unit govuk--field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
     <div class="field-unit__label">
         <%= f.label attribute.attribute, 'Unique alias' %>
     </div>
@@ -50,7 +34,8 @@ and renders all form fields for a resource's editable attributes.
     </div>
   </div>
 
-  <div class="form-actions">
-    <%= f.submit %>
+  <div class="form-actions govuk--form-actions">
+    <%= f.button type: :submit, class: %w[govuk-button] %>
+    <%= link_to 'Cancel', [:admin, page.resource], class: %w[govuk-button govuk-button--secondary] %>
   </div>
 <% end %>

--- a/app/views/admin/datasets/_resource.html.erb
+++ b/app/views/admin/datasets/_resource.html.erb
@@ -1,0 +1,19 @@
+<tr class="govuk-table__row" scope="row">
+  <td data-label="<%= t('admin.datasets.name') %>" class="govuk-table__cell left govuk-!-padding-left-0" scope="col">
+    <%= resource.name %>
+  </td>
+  <td data-label="<%= t('admin.datasets.tab_name') %>" class="govuk-table__cell" scope="col">
+    <%= resource.tab_name %>
+  </td>
+  <td data-label="<%= t('admin.datasets.data_items') %>" class="govuk-table__cell govuk-!-width-one-sixth right" scope="col">
+    <%= resource.data_elements.count %>
+  </td>
+  <td data-label="<%= t('admin.actions.view_details') %>" class="govuk-table__cell govuk-!-width-one-fifth govuk-!-padding-right-0 right" scope="col">
+    <%= link_to t('admin.actions.view_details'),
+                [:admin, resource],
+                { class: 'action-show' } %>
+    <%= link_to t('admin.actions.edit'),
+                [:edit, :admin, resource]%>
+  </td>
+</tr>
+

--- a/app/views/admin/datasets/edit.html.erb
+++ b/app/views/admin/datasets/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) do %>
-  <%= t('admin.categories.actions.edit') %>
+  <%= t('admin.datasets.actions.edit') %>
 <% end %>
 
 <div class="govuk-grid-row govuk-!-margin-top-0">
@@ -19,7 +19,7 @@
       <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
         <%= link_to(
           t('actions.destroy', name: page.resource.class.name),
-          [:delete_confirmation, :admin, :categories, id: page.resource.id],
+          [:delete_confirmation, :admin, :datasets, id: page.resource.id],
           class: 'govuk-button govuk-button--warning'
         ) if show_action? :destroy, page.resource %>
       </p>

--- a/app/views/admin/datasets/index.html.erb
+++ b/app/views/admin/datasets/index.html.erb
@@ -1,0 +1,55 @@
+<% content_for(:title) do %>
+  <%= t('admin.datasets.title') %>
+<% end %>
+
+<%= render 'shared/admin/header' %>
+
+<section class="main-content__body main-content__body--flush">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column govuk-grid-column-two-thirds govuk-!-margin-bottom-7">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column govuk-grid-column-full govuk-!-margin-bottom-2">
+          <%= render(
+            'search',
+            search_term: search_term,
+            resource_name: t('admin.datasets.datasets').downcase
+          ) %>
+        </div>
+      </div>
+      <div class="govuk-grid-row govuk-!-margin-top-2 govuk-!-margin-bottom-7">
+        <div class="govuk-grid-column-full govuk-!-margin-top-5">
+          <% if resources.any? -%>
+            <%= render 'shared/admin/flexible_pagination', resources: resources %>
+
+            <%= render(
+              "collection",
+              collection_presenter: page,
+              collection_field_name: resource_name,
+              page: page,
+              resources: resources,
+              table_title: "page-title"
+            ) %>
+
+            <%= render 'shared/admin/flexible_pagination', resources: resources %>
+          <%- else -%>
+            <p class="govuk-body"><%= t('admin.datasets.no_datasets') %></p>
+          <%- end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
+      <div class="govuk-top-border">
+        <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
+        <%= t('actions.actions') %>
+        </p>
+        <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
+        <%= link_to(t('admin.datasets.actions.create'),
+                    [:new, :admin, :dataset],
+                    class: %w[govuk-!-margin-bottom-1]
+                   ) if valid_action?(:new) && show_action?(:new, Dataset.new) %>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/admin/datasets/show.html.erb
+++ b/app/views/admin/datasets/show.html.erb
@@ -1,0 +1,94 @@
+<% resource = page.resource %>
+<% content_for(:title) do %>
+  <%= page.resource.name %>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-margin-top-0">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+    <%= render 'shared/admin/header' %>
+
+    <section class="main-content__body main-content__body--flush">
+      <div class="govuk-grid-row govuk-!-margin-0">
+        <div class="govuk-grid-column-full govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+          <table aria-labelledby="<%= resource.name %>" class="govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+            <tbody>
+              <tr>
+                <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
+                  <%= t('admin.datasets.id') %>
+                </td>
+                <td colspan="3" data-label="<%= t('admin.datasets.id') %>" class="govuk-table__cell govuk-body">
+                  <%= resource.id %>
+                </td>
+              </tr>
+              <tr>
+                <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
+                  <%= t('admin.datasets.tab_name') %>
+                </td>
+                <td colspan="3" data-label="<%= t('admin.datasets.tab_name') %>" class="govuk-table__cell govuk-body">
+                  <%= resource.tab_name %>
+                </td>
+              </tr>
+              <tr>
+                <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
+                  <%= t('admin.datasets.description') %>
+                </td>
+                <td colspan="3" data-label="<%= t('admin.datasets.description') %>" class="govuk-table__cell govuk-body">
+                  <%= resource.description %>
+                </td>
+              </tr>
+              <tr>
+                <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
+                  <%= t('admin.datasets.created_at') %>
+                </td>
+                <td colspan="3" data-label="<%= t('admin.datasets.created_at') %>" class="govuk-table__cell govuk-body">
+                  <%= I18n.localize(resource.created_at.in_time_zone('GB'), format: :default ) %>
+                </td>
+              </tr>
+              <tr>
+                <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
+                  <%= t('admin.datasets.updated_at') %>
+                </td>
+                <td colspan="3" data-label="<%= t('admin.datasets.updated_at') %>" class="govuk-table__cell govuk-body">
+                  <%= I18n.localize(resource.updated_at.in_time_zone('GB'), format: :default ) %>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <% if resource.data_elements.any? -%>
+        <div class="govuk-grid-row govuk-!-margin-0">
+          <div class="govuk-grid-column-full govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+            <h2 class="govuk-heading-m"><%= t('admin.datasets.data_items') %></h2>
+            <% records_per_page = 5 %>
+            <% data_items = resource.data_elements.page(params[:page]).per(records_per_page) %>
+
+            <%= render 'shared/admin/flexible_pagination', resources: data_items %>
+
+            <%= render 'admin/data_elements/collection',
+              collection_presenter: page,
+              collection_field_name: 'data_item',
+              page: page,
+              resources: data_items,
+              table_title: "page-title" %>
+
+            <%= render 'shared/admin/flexible_pagination', resources: data_items %>
+          </div>
+        </div>
+      <%- end %>
+    </section>
+  </div>
+
+  <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
+    <div class="govuk-top-border">
+      <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
+        <%= t('actions.actions') %>
+      </p>
+      <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
+        <% if valid_action?(:edit, 'dataset') && show_action?(:edit, resource) %>
+          <%= link_to t('admin.datasets.actions.edit'), [:edit, namespace, resource]%>
+        <% end %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -262,6 +262,17 @@ en:
         errors:
           missing_data: Can't assign data items to concept if the data items or the concept are missing.
           refused: Action cancelled by the user, data items not assigned.
+    datasets:
+      title: All datasets
+      datasets: Datasets
+      no_datasets: No datasets found
+      name: Name
+      tab_name: Tab name
+      data_items: Data items
+      actions:
+        create: Create a new dataset
+        edit: Edit dataset
+        delete: Delete dataset
     data_tables:
       dataset: Dataset name
       unique_alias: Unique alias column

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -266,9 +266,13 @@ en:
       title: All datasets
       datasets: Datasets
       no_datasets: No datasets found
+      id: ID
       name: Name
       tab_name: Tab name
+      description: Description
       data_items: Data items
+      created_at: Created at
+      updated_at: Updated at
       actions:
         create: Create a new dataset
         edit: Edit dataset

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,10 @@ Rails.application.routes.draw do
       get  'abort_import(/:id)', to: 'import_datasets#abort_import',
                                  as: :abort_import
     end
+    resource :datasets, only: [] do
+      get  ':id/delete_confirmation', to: 'datasets#delete_confirmation',
+        as: :delete_confirmation
+    end
     resources :datasets
     resources :admin_users
     resource :admin_user, only: [] do


### PR DESCRIPTION
# Admin Area: redesign 'All datasets' pages 

## Development

Redesign the datasets index, view, edit and destroy pages.

## Screenshots

### Datasets index, unfiltered

![01_datasets_index_unfiltered](https://user-images.githubusercontent.com/2742327/112957584-79597000-9139-11eb-8481-0fcdbb5678ff.jpg)

### Datasets index, filtered

![02_datasets_index_filtered](https://user-images.githubusercontent.com/2742327/112957631-87a78c00-9139-11eb-88b3-6c85c0553b6b.jpg)

### Dataset details

![03_datasets_show](https://user-images.githubusercontent.com/2742327/112957653-8d04d680-9139-11eb-84f6-26ea976e2236.jpg)

### Dataset edit

![04_datasets_edit](https://user-images.githubusercontent.com/2742327/112957685-94c47b00-9139-11eb-8946-56b946fcb7ad.jpg)

### Dataset delete confirmation

![05_datasets_delete_confirmation](https://user-images.githubusercontent.com/2742327/112957786-b160b300-9139-11eb-8bb7-5a107b2b1c14.jpg)
