### PR TITLE
Dev #702 - Fix issue where aborting the 'delete dataset' action would still delete the dataset

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -32,7 +32,7 @@ module Admin
 
     def destroy
       if params.dig(:delete) && params.dig(:delete) == 'no'
-        flash[:notice] = translate_with_resource('destroy.aborted')
+        flash[:notice] = I18n.translate('admin.shared.destroy_aborted', name: requested_resource.class.name)
       elsif requested_resource.destroy
         flash[:notice] = translate_with_resource('destroy.success')
       else

--- a/app/controllers/admin/datasets_controller.rb
+++ b/app/controllers/admin/datasets_controller.rb
@@ -8,16 +8,20 @@ module Admin
     before_action :generate_back_breadcrumbs, only: %i[show new edit create update]
 
     def destroy
-      requested_resource.data_table_tabs.destroy_all
-      requested_resource
-        .data_elements
-        .select { |data_element| data_element.datasets.count < 2 }
-        .each(&:destroy)
-
-      if requested_resource.destroy
-        flash[:notice] = translate_with_resource('destroy.success')
+      if params.dig(:delete) && params.dig(:delete) == 'no'
+        flash[:notice] = I18n.translate('admin.shared.destroy_aborted', name: requested_resource.class.name)
       else
-        flash[:error] = requested_resource.errors.full_messages.join('<br/>')
+        requested_resource.data_table_tabs.destroy_all
+        requested_resource
+          .data_elements
+          .select { |data_element| data_element.datasets.count < 2 }
+          .each(&:destroy)
+
+        if requested_resource.destroy
+          flash[:notice] = translate_with_resource('destroy.success')
+        else
+          flash[:error] = requested_resource.errors.full_messages.join('<br/>')
+        end
       end
       redirect_to action: :index
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,6 +160,7 @@ en:
       destroy_confirmation: "Delete %{name}?"
       destroy_confirmation_yes: "Yes, delete %{name}"
       destroy_confirmation_no: "No, do not delete %{name}"
+      destroy_aborted: "%{name} not deleted. Action cancelled by user."
     home:
       title: '"Find and Explore" NPD Admin tool'
       menu:


### PR DESCRIPTION
# Fix issue where aborting the 'delete dataset' action would still delete the dataset

## Development

Fix bug found by @dgamblin3008:

https://github.com/DFE-Digital/npd-find-and-explore/issues/702#issuecomment-811096834