### PR TITLE
Dev #705 - Admin Area: redesign 'Create categories and concepts backup file' pages

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class CategoriesController < Admin::ApplicationController
     helper NestableHelper
 
-    layout :layout_by_resource
+    layout 'admin/application'
 
     before_action :generate_breadcrumbs, only: %i[new create update]
     before_action :generate_back_breadcrumbs, only: %i[show edit]
@@ -74,7 +74,12 @@ module Admin
       custom_breadcrumbs_for(admin: true,
                              leaf: t('admin.home.menu.import_export.links.import_ia_file'))
 
-      render :import, layout: layout_by_resource, locals: { success: nil, errors: [] }
+      render :import, layout: 'admin/application', locals: { success: nil, errors: [] }
+    end
+
+    def export
+      custom_breadcrumbs_for(admin: true,
+                             leaf: t('admin.home.menu.import_export.links.export_ia_file'))
     end
 
     def preprocess
@@ -150,14 +155,6 @@ module Admin
       Category.search(search_term)
               .includes(:concepts)
               .order(:name)
-    end
-
-    def layout_by_resource
-      if %w[index new create show edit update childless import].include?(params[:action])
-        'admin/application'
-      else
-        'admin/side_menu'
-      end
     end
 
     def generate_breadcrumbs

--- a/app/javascript/packs/category_download.js
+++ b/app/javascript/packs/category_download.js
@@ -32,6 +32,7 @@ $(document).ready(function() {
     $('#download-link').removeAttr('disabled')
     window.loader.stop()
     $('#govuk-box-container').hide();
+    $('#govuk-box-success').show();
     window.clearInterval(downloadTimer);
     document.cookie = document.cookie.replace(/download=download-ia-table/, 'download=download-ia-table;path=/;max-age=1');
   }

--- a/app/javascript/packs/category_download.js
+++ b/app/javascript/packs/category_download.js
@@ -8,13 +8,19 @@ window.loader = new GOVUK.Loader()
 $(document).ready(function() {
   var downloadTimer;
 
-  $('#download-link').on('click', function() {
+  $('#download-link').on('click', function(event) {
+    if ($(event.currentTarget).attr('disabled')) {
+      return;
+    }
+
     $('#download-link').attr('disabled', true)
+    $('#govuk-box-container').show();
 
     window.loader.init({
       container: 'govuk-box-message',
       label: true,
-      labelText: 'We are generating the file you requested, please wait'
+      labelText: '',
+      size: '175px',
     })
 
     downloadTimer = window.setInterval(function() {
@@ -25,6 +31,7 @@ $(document).ready(function() {
   var finishDownload = function() {
     $('#download-link').removeAttr('disabled')
     window.loader.stop()
+    $('#govuk-box-container').hide();
     window.clearInterval(downloadTimer);
     document.cookie = document.cookie.replace(/download=download-ia-table/, 'download=download-ia-table;path=/;max-age=1');
   }

--- a/app/javascript/packs/category_upload.js
+++ b/app/javascript/packs/category_upload.js
@@ -6,6 +6,7 @@ $(document).on('ajax:success', function(event) {
   var data = detail[0], status = detail[1], xhr = detail[2]
 
   setTimeout(function() {
+    $('#govuk-box-container').hide();
     document.querySelector('#form-group').outerHTML = detail[0].body.innerHTML
     document.getElementById('submit-upload').removeAttribute('disabled')
   }, 500)

--- a/app/javascript/packs/loader.js
+++ b/app/javascript/packs/loader.js
@@ -6,15 +6,20 @@ window.loader = new GOVUK.Loader()
 
 $(document).ready(function() {
   $('.loader-on-submit').submit(function(event) {
+    if ($(event.currentTarget).attr('disabled')) {
+      return;
+    }
+
     $(event.currentTarget).parents('.govuk-form-group').removeClass('govuk-form-group--error');
     $(event.currentTarget).find('.govuk-error-message').hide();
     $('button').attr('disabled', true);
-    $('#govuk-box-message').show();
+    $('#govuk-box-container').show();
 
     window.loader.init({
       container: 'govuk-box-message',
       label: true,
-      labelText: 'We are processing the file you uploaded, please wait'
+      labelText: '',
+      size: '175px',
     });
   });
 });

--- a/app/javascript/src/_govuk-overrides.scss
+++ b/app/javascript/src/_govuk-overrides.scss
@@ -158,6 +158,10 @@
   background-color: govuk-colour('light-grey');
 }
 
+.govuk-align-center {
+  text-align: center;
+}
+
 .govuk-\!-width-one-fifth {
   width: 20% !important;
 }

--- a/app/javascript/src/loader.scss
+++ b/app/javascript/src/loader.scss
@@ -1,14 +1,18 @@
 @import "node_modules/govuk-frontend/govuk/helpers/colour";
 
-#govuk-box-container {
+#govuk-box-container, #govuk-box-success {
   background-color: govuk-colour('white');
   display: none;
-  height: 300px;
-  left: 0;
+  height: 280px;
+  left: auto;
   position: fixed;
   top: 170px;
   width: 100%;
   z-index: 1000;
+}
+
+#govuk-box-container {
+  left: 0;
 }
 
 .govuk-c-loader {

--- a/app/javascript/src/loader.scss
+++ b/app/javascript/src/loader.scss
@@ -1,3 +1,16 @@
+@import "node_modules/govuk-frontend/govuk/helpers/colour";
+
+#govuk-box-container {
+  background-color: govuk-colour('white');
+  display: none;
+  height: 300px;
+  left: 0;
+  position: fixed;
+  top: 170px;
+  width: 100%;
+  z-index: 1000;
+}
+
 .govuk-c-loader {
   line-height: 0;
   position: relative;

--- a/app/views/admin/categories/_import_form.html.erb
+++ b/app/views/admin/categories/_import_form.html.erb
@@ -18,7 +18,6 @@
         <%= t('forms.upload_successful') %>
       </p>
     <% end %>
-    <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
     <button type="submit" class="govuk-button" id="submit-upload"><%= t('forms.continue') %></button>
   <%- end %>
 </div>

--- a/app/views/admin/categories/export.html.erb
+++ b/app/views/admin/categories/export.html.erb
@@ -19,3 +19,20 @@
   <h2 class="govuk-heading-l govuk-align-center"><%= t('admin.categories.export.creating').html_safe %></h2>
   <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
 </div>
+<div id="govuk-box-success">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h2 class="govuk-panel__title">
+          <%= t('admin.categories.export.created.title').html_safe %>
+        </h2>
+      </div>
+      <p class="govuk-body">
+        <%= t('admin.categories.export.created.subtitle').html_safe %>
+      </p>
+      <p class="govuk-body">
+        <%= link_to t('forms.continue_to_home'), admin_root_path %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/categories/export.html.erb
+++ b/app/views/admin/categories/export.html.erb
@@ -1,5 +1,8 @@
 <% content_for(:title) do %>
-  Generate new IA document
+  <%= t('admin.categories.export.title') %>
+<% end %>
+<% content_for(:subtitle) do %>
+  <%= t('admin.categories.export.subtitle') %>
 <% end %>
 
 <% content_for(:additional_tags) do %>
@@ -7,13 +10,12 @@
   <%= javascript_pack_tag 'category_download' %>
 <% end %>
 
-<header class="main-content__header" role="banner">
-  <h1 class="main-content__page-title" id="page-title">
-    <%= content_for(:title) %>
-  </h1>
-</header>
+<%= render 'shared/admin/header' %>
 
-<fieldset class="govuk-fieldset govuk-!-margin-2" aria-describedby="download-file-hint download-file-error" role="group">
-  <%= link_to 'Download', download_admin_categories_path, class: 'govuk-button', id: 'download-link' %>
+<fieldset class="govuk-fieldset govuk-!-margin-0" aria-describedby="download-file-hint download-file-error" role="group">
+  <%= link_to t('forms.continue'), download_admin_categories_path, class: 'govuk-button govuk-!-margin-left-0', id: 'download-link' %>
 </fieldset>
-<div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
+<div id="govuk-box-container">
+  <h2 class="govuk-heading-l govuk-align-center"><%= t('admin.categories.export.creating').html_safe %></h2>
+  <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
+</div>

--- a/app/views/admin/categories/import.html.erb
+++ b/app/views/admin/categories/import.html.erb
@@ -10,6 +10,10 @@
 
 <%= render 'shared/admin/header' %>
 
-<fieldset class="govuk-fieldset govuk-!-margin-2" aria-describedby="upload-file-hint upload-file-error" role="group">
+<fieldset class="govuk-fieldset govuk-!-margin-0" aria-describedby="upload-file-hint upload-file-error" role="group">
   <%= render partial: 'import_form', locals: { success: success, errors: errors } %>
 </fieldset>
+<div id="govuk-box-container">
+  <h2 class="govuk-heading-l govuk-align-center"><%= t('admin.categories.export.creating').html_safe %></h2>
+  <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,6 +209,10 @@ en:
       import:
         title: Import categories and concepts backup file
         label: Categories and concepts backup file to import
+      export:
+        title: Create categories and concepts backup file
+        subtitle: Create new categories and concepts backup file
+        creating: Creating categories and concepts<br/>backup file
     concepts:
       actions:
         create: Create a new concept

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,6 +213,9 @@ en:
         title: Create categories and concepts backup file
         subtitle: Create new categories and concepts backup file
         creating: Creating categories and concepts<br/>backup file
+        created:
+          title: Backup file successfully created
+          subtitle: The categories and concepts backup file has been successfully created.
     concepts:
       actions:
         create: Create a new concept
@@ -339,6 +342,7 @@ en:
     or: or
     changes_approved: Changes have been approved
     upload_successful: The file was processed and uploaded successfully
+    continue_to_home: 'Continue to "NPD Admin" home'
 
   date:
     formats:


### PR DESCRIPTION
# Admin Area: redesign 'Create categories and concepts backup file' pages

## Development

Redesign the generation of the category and concept backup file.

## Screenshots

### Landing page

![01_export_ia_landing](https://user-images.githubusercontent.com/2742327/113218830-1b7f7200-9278-11eb-8520-3a164d54e815.jpg)

### Generating file

![02_export_ia_loader](https://user-images.githubusercontent.com/2742327/113218867-29cd8e00-9278-11eb-872e-b36273a5c733.jpg)

### Success screen

![03_export_ia_success](https://user-images.githubusercontent.com/2742327/113218879-305c0580-9278-11eb-8ff4-0c3dc25632c0.jpg)
