### PR TITLE
Dev #706 - Admin Area: redesign 'Manage admin users' pages

### DIFF
--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -2,15 +2,9 @@
 
 module Admin
   class AdminUsersController < Admin::ApplicationController
-    # To customize the behavior of this controller,
-    # you can overwrite any of the RESTful actions. For example:
-    #
-    # def index
-    #   super
-    #   @resources = AdminUser.
-    #     page(params[:page]).
-    #     per(10)
-    # end
+    layout 'admin/application'
+    before_action :generate_back_breadcrumbs, only: %i[show edit create update]
+    before_action :generate_breadcrumbs, only: %i[index]
 
     def edit
       if requested_resource == current_admin_user
@@ -38,12 +32,11 @@ module Admin
       redirect_to action: :index
     end
 
-    # Define a custom finder by overriding the `find_resource` method:
-    # def find_resource(param)
-    #   AdminUser.find_by!(slug: param)
-    # end
+  private
 
-    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
-    # for more information
+    def generate_breadcrumbs
+      custom_breadcrumbs_for(admin: true,
+                             leaf: I18n.t('admin.home.menu.admin.links.users'))
+    end
   end
 end

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -5,6 +5,7 @@ module Admin
     layout 'admin/application'
     before_action :generate_back_breadcrumbs, only: %i[show edit create update]
     before_action :generate_breadcrumbs, only: %i[index]
+    before_action :set_minimum_password_length, only: %i[new edit create update]
 
     def edit
       if requested_resource == current_admin_user
@@ -37,6 +38,10 @@ module Admin
     def generate_breadcrumbs
       custom_breadcrumbs_for(admin: true,
                              leaf: I18n.t('admin.home.menu.admin.links.users'))
+    end
+
+    def set_minimum_password_length
+      @minimum_password_length = Devise.password_length&.min
     end
   end
 end

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class AdminUsersController < Admin::ApplicationController
     layout 'admin/application'
-    before_action :generate_back_breadcrumbs, only: %i[show edit create update]
+    before_action :generate_back_breadcrumbs, only: %i[show new edit create update]
     before_action :generate_breadcrumbs, only: %i[index]
     before_action :set_minimum_password_length, only: %i[new edit create update]
 
@@ -15,18 +15,42 @@ module Admin
       end
     end
 
+    def deactivate_confirmation
+      requested_resource
+
+      render :deactivate_confirmation,
+             layout: 'admin/application',
+             locals: {
+             page: Administrate::Page::Form.new(dashboard, requested_resource)
+      }
+    end
+
     def deactivate
       if requested_resource == current_admin_user
         flash[:error] = "Can't deactivate self!"
+      elsif params.dig(:deactivate) && params.dig(:deactivate) == 'no'
+        flash[:notice] = I18n.translate('admin.admin_users.deactivate_aborted', name: 'User')
       else
         requested_resource.deactivate!
       end
       redirect_to action: :index
     end
 
+    def reactivate_confirmation
+      requested_resource
+
+      render :reactivate_confirmation,
+             layout: 'admin/application',
+             locals: {
+             page: Administrate::Page::Form.new(dashboard, requested_resource)
+      }
+    end
+
     def reactivate
       if requested_resource == current_admin_user
         flash[:error] = "Can't reactivate self!"
+      elsif params.dig(:reactivate) && params.dig(:reactivate) == 'no'
+        flash[:notice] = I18n.translate('admin.admin_users.reactivate_aborted', name: 'User')
       else
         requested_resource.reactivate!
       end

--- a/app/views/admin/admin_users/_collection.html.erb
+++ b/app/views/admin/admin_users/_collection.html.erb
@@ -22,7 +22,7 @@
 <div class="govuk-!-margin-top-7">
   <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-0 flex-pagination">
     <h2 class="govuk-heading-m" id="page-subtitle"><%= t('admin.admin_users.inactive') %></h2>
-    <span class="page-entries-info"><%= page_entries_info resources.active %></span>
+    <span class="page-entries-info"><%= page_entries_info resources.inactive %></span>
   </div>
   <table aria-labelledby="<%= table_title %>-inactive">
     <thead>

--- a/app/views/admin/admin_users/_collection.html.erb
+++ b/app/views/admin/admin_users/_collection.html.erb
@@ -1,175 +1,41 @@
-<%#
-# Collection
-
-This partial is used on the `index` and `show` pages
-to display a collection of resources in an HTML table.
-
-## Local variables:
-
-- `collection_presenter`:
-  An instance of [Administrate::Page::Collection][1].
-  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
-  the columns displayed in the table
-- `resources`:
-  An ActiveModel::Relation collection of resources to be displayed in the table.
-  By default, the number of resources is limited by pagination
-  or by a hard limit to prevent excessive page load times
-
-[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
-%>
-
-<br />
-<h2 class="" id="page-subtitle"> Active Admin Users</h2>
-<table aria-labelledby="<%= table_title %>">
-  <thead>
-    <tr>
-      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
-        <th class="cell-label
-        cell-label--<%= attr_type.html_class %>
-        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>"
-        scope="col"
-        role="columnheader"
-        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
-        <%= link_to(sanitized_order_params(page, collection_field_name).merge(
-          collection_presenter.order_params_for(attr_name, key: collection_field_name)
-        )) do %>
-        <%= t(
-          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
-          default: attr_name.to_s,
-        ).titleize %>
-            <% if collection_presenter.ordered_by?(attr_name) %>
-              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
-                <svg aria-hidden="true">
-                  <use xlink:href="#icon-up-caret" />
-                </svg>
-              </span>
-            <% end %>
-          <% end %>
-        </th>
-      <% end %>
-      <% [valid_action?(:edit, collection_presenter.resource_name),
-          valid_action?(:destroy, collection_presenter.resource_name)].count(true).times do %>
-        <th scope="col"></th>
-      <% end %>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% resources.active.each do |resource| %>
-      <tr class="js-table-row"
-          tabindex="0"
-          <% if valid_action? :show, collection_presenter.resource_name %>
-            <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
-          <% end %>
-          >
-        <% collection_presenter.attributes_for(resource).each do |attribute| %>
-          <td class="cell-data cell-data--<%= attribute.html_class %>">
-            <% if show_action? :show, resource -%>
-              <a href="<%= polymorphic_path([namespace, resource]) -%>"
-                 class="action-show"
-                 >
-                <%= render_field attribute %>
-              </a>
-            <% end -%>
-          </td>
-        <% end %>
-
-        <% if valid_action? :edit, collection_presenter.resource_name %>
-          <td><%= link_to(
-            t("administrate.actions.edit"),
-            [:edit, namespace, resource],
-            class: "action-edit",
-          ) if show_action? :edit, resource%></td>
-        <% end %>
-
-        <% if resource.account_active? && valid_action?(:deactivate, collection_presenter.resource_name) %>
-          <td><%= link_to(
-            t("administrate.actions.deactivate"),
-            [:deactivate, namespace, resource],
-            class: "text-color-red",
-            method: :put,
-            data: { confirm: t("administrate.actions.confirm") }
-          ) if show_action? :deactivate, resource %></td>
-        <% end %>
+<div class="govuk-!-margin-top-3">
+  <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-0 flex-pagination">
+    <h2 class="govuk-heading-m" id="page-subtitle"><%= t('admin.admin_users.active') %></h2>
+    <span class="page-entries-info"><%= page_entries_info resources.active %></span>
+  </div>
+  <table aria-labelledby="<%= table_title %>">
+    <thead>
+      <tr class="govuk-!-border-none">
+        <th class="govuk-!-width-two-fifths"></th>
+        <th class="govuk-!-width-one-fifth"></th>
+        <th class="govuk-!-width-two-fifths"></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
-
-<br />
-<h2 class="" id="page-subtitle"> Inactive Admin Users</h2>
-<table aria-labelledby="<%= table_title %>-inactive">
-  <thead>
-    <tr>
-      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
-        <th class="cell-label
-        cell-label--<%= attr_type.html_class %>
-        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>"
-        scope="col"
-        role="columnheader"
-        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
-        <%= link_to(sanitized_order_params(page, collection_field_name).merge(
-          collection_presenter.order_params_for(attr_name, key: collection_field_name)
-        )) do %>
-        <%= t(
-          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
-          default: attr_name.to_s,
-        ).titleize %>
-            <% if collection_presenter.ordered_by?(attr_name) %>
-              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
-                <svg aria-hidden="true">
-                  <use xlink:href="#icon-up-caret" />
-                </svg>
-              </span>
-            <% end %>
-          <% end %>
-        </th>
+    </thead>
+    <tbody>
+      <% resources.active.each do |resource| %>
+        <%= render 'admin/admin_users/resource', resource: resource, collection_presenter: collection_presenter %>
       <% end %>
-      <% [valid_action?(:edit, collection_presenter.resource_name),
-          valid_action?(:destroy, collection_presenter.resource_name)].count(true).times do %>
-        <th scope="col"></th>
-      <% end %>
-    </tr>
-  </thead>
+    </tbody>
+  </table>
+</div>
 
-  <tbody>
-    <% resources.inactive.each do |resource| %>
-      <tr class="js-table-row js-table-row-inactive"
-          tabindex="0"
-          <% if valid_action? :show, collection_presenter.resource_name %>
-            <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
-          <% end %>
-          >
-        <% collection_presenter.attributes_for(resource).each do |attribute| %>
-          <td class="cell-data cell-data--<%= attribute.html_class %>">
-            <% if show_action? :show, resource -%>
-              <a href="<%= polymorphic_path([namespace, resource]) -%>"
-                 class="action-show"
-                 >
-                <%= render_field attribute %>
-              </a>
-            <% end -%>
-          </td>
-        <% end %>
-
-        <% if valid_action? :edit, collection_presenter.resource_name %>
-          <td><%= link_to(
-            t("administrate.actions.edit"),
-            [:edit, namespace, resource],
-            class: "action-edit",
-          ) if show_action? :edit, resource%></td>
-        <% end %>
-
-        <% if !resource.account_active? && valid_action?(:reactivate, collection_presenter.resource_name) %>
-          <td><%= link_to(
-            t("administrate.actions.reactivate"),
-            [:reactivate, namespace, resource],
-            class: "text-color-red",
-            method: :put,
-            data: { confirm: t("administrate.actions.confirm") }
-          ) if show_action? :reactivate, resource %></td>
-        <% end %>
+<div class="govuk-!-margin-top-7">
+  <div class="govuk-!-margin-top-2 govuk-!-margin-bottom-0 flex-pagination">
+    <h2 class="govuk-heading-m" id="page-subtitle"><%= t('admin.admin_users.inactive') %></h2>
+    <span class="page-entries-info"><%= page_entries_info resources.active %></span>
+  </div>
+  <table aria-labelledby="<%= table_title %>-inactive">
+    <thead>
+      <tr class="govuk-!-border-none">
+        <th class="govuk-!-width-two-fifths"></th>
+        <th class="govuk-!-width-one-fifth"></th>
+        <th class="govuk-!-wihth-two-fifths"></td>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% resources.inactive.each do |resource| %>
+        <%= render 'admin/admin_users/resource', resource: resource, collection_presenter: collection_presenter %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/admin_users/_form.html.erb
+++ b/app/views/admin/admin_users/_form.html.erb
@@ -1,19 +1,3 @@
-<%#
-# Form Partial
-
-This partial is rendered on a resource's `new` and `edit` pages,
-and renders all form fields for a resource's editable attributes.
-
-## Local variables:
-
-- `page`:
-  An instance of [Administrate::Page::Form][1].
-  Contains helper methods to display a form,
-  and knows which attributes should be displayed in the resource's form.
-
-[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
-%>
-
 <%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
   <% if page.resource.errors.any? %>
     <div id="error_explanation">
@@ -33,23 +17,51 @@ and renders all form fields for a resource's editable attributes.
     </div>
   <% end %>
 
-  <div class="field-unit field-unit--string field-unit--optional">
-    <div class="field-unit__label">
-      <label for="admin_user_email">Email</label>
-    </div>
-    <div class="field-unit__field">
-      <input type="text" value="<%= page.page_title %>" name="admin_user[email]" id="admin_user_email" <%= page.resource.persisted? ? 'disabled' : '' %>>
-    </div>
+  <div class="govuk-form-group">
+    <% if page.resource.persisted? -%>
+      <h2 class="govuk-heading-m"><%= page.resource.email %></h2>
+    <%- else -%>
+      <%= f.label :email, t('admin.admin_users.email'), class: 'govuk-label' %>
+      <%= f.text_field :email, autocomplete: 'new-email', class: 'govuk-input' %>
+    <%- end %>
   </div>
 
-  <% page.attributes.each do |attribute| -%>
-    <% next if attribute.name.to_s == 'email' %>
-    <div class="field-unit field-unit--<%= attribute.html_class %>">
-      <%= render_field attribute, f: f %>
-    </div>
-  <% end -%>
+  <div class="govuk-form-group">
+    <%= f.label :password, t('admin.admin_users.password_and_hint'), class: 'govuk-label' %>
+    <% if @minimum_password_length %>
+      <div class="govuk-hint"><%= t('devise.passwords.format', length: @minimum_password_length) %></div>
+    <% end %>
+    <%= f.password_field :password, autocomplete: 'new-password', class: 'govuk-input' %>
+    <% if f.object.errors[:password].present? %>
+      <span class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span> <%= f.object.errors[:password].map(&:capitalize).join(', ') %>
+      </span>
+    <% end %>
+  </div>
 
-  <div class="form-actions">
-    <%= f.submit %>
+  <div class="govuk-form-group">
+    <%= f.label :password_confirmation, t('admin.admin_users.password_confirmation'), class: 'govuk-label' %>
+    <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'govuk-input' %>
+    <% if f.object.errors[:password_confirmation].present? %>
+      <span class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span> <%= f.object.errors[:password_confirmation].map(&:capitalize).join(', ') %>
+      </span>
+    <% end %>
+  </div>
+
+  <div class="govuk-form-group">
+    <%= f.label :current_password, t('admin.admin_users.current_password'), class: 'govuk-label' %>
+    <div class="govuk-hint"><%= t('admin.admin_users.current_password_hint') %></div>
+    <%= f.password_field :current_password, autocomplete: 'current-password', class: 'govuk-input' %>
+    <% if f.object.errors[:current_password].present? %>
+      <span class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span> <%= f.object.errors[:current_password].map(&:capitalize).join(', ') %>
+      </span>
+    <% end %>
+  </div>
+
+  <div class="form-actions govuk--form-actions">
+    <%= f.button type: :submit, class: %w[govuk-button] %>
+    <%= link_to 'Cancel', [:admin, page.resource], class: %w[govuk-button govuk-button--secondary] %>
   </div>
 <% end %>

--- a/app/views/admin/admin_users/_form.html.erb
+++ b/app/views/admin/admin_users/_form.html.erb
@@ -27,7 +27,11 @@
   </div>
 
   <div class="govuk-form-group">
-    <%= f.label :password, t('admin.admin_users.password_and_hint'), class: 'govuk-label' %>
+    <% if page.resource.persisted? -%>
+      <%= f.label :password, t('admin.admin_users.password_and_hint'), class: 'govuk-label' %>
+    <%- else -%>
+      <%= f.label :password, t('admin.admin_users.password'), class: 'govuk-label' %>
+    <%- end %>
     <% if @minimum_password_length %>
       <div class="govuk-hint"><%= t('devise.passwords.format', length: @minimum_password_length) %></div>
     <% end %>
@@ -49,16 +53,18 @@
     <% end %>
   </div>
 
-  <div class="govuk-form-group">
-    <%= f.label :current_password, t('admin.admin_users.current_password'), class: 'govuk-label' %>
-    <div class="govuk-hint"><%= t('admin.admin_users.current_password_hint') %></div>
-    <%= f.password_field :current_password, autocomplete: 'current-password', class: 'govuk-input' %>
-    <% if f.object.errors[:current_password].present? %>
-      <span class="govuk-error-message">
-        <span class="govuk-visually-hidden">Error:</span> <%= f.object.errors[:current_password].map(&:capitalize).join(', ') %>
-      </span>
-    <% end %>
-  </div>
+  <% if page.resource.persisted? -%>
+    <div class="govuk-form-group">
+      <%= f.label :current_password, t('admin.admin_users.current_password'), class: 'govuk-label' %>
+      <div class="govuk-hint"><%= t('admin.admin_users.current_password_hint') %></div>
+      <%= f.password_field :current_password, autocomplete: 'current-password', class: 'govuk-input' %>
+      <% if f.object.errors[:current_password].present? %>
+        <span class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span> <%= f.object.errors[:current_password].map(&:capitalize).join(', ') %>
+        </span>
+      <% end %>
+    </div>
+  <%- end %>
 
   <div class="form-actions govuk--form-actions">
     <%= f.button type: :submit, class: %w[govuk-button] %>

--- a/app/views/admin/admin_users/_resource.html.erb
+++ b/app/views/admin/admin_users/_resource.html.erb
@@ -17,19 +17,17 @@
       <% if resource.account_active? && valid_action?(:deactivate, collection_presenter.resource_name) %>
         <%= link_to(
           t("administrate.actions.deactivate"),
-          [:deactivate, namespace, resource],
+          [:deactivate_confirmation, namespace, resource],
           class: "text-color-red",
-          method: :put,
-          data: { confirm: t("administrate.actions.confirm") }
+          method: :get
         ) if show_action? :deactivate, resource %>
       <% end %>
       <% if !resource.account_active? && valid_action?(:reactivate, collection_presenter.resource_name) %>
         <%= link_to(
           t("administrate.actions.reactivate"),
-          [:reactivate, namespace, resource],
+          [:reactivate_confirmation, namespace, resource],
           class: "text-color-red",
-          method: :put,
-          data: { confirm: t("administrate.actions.confirm") }
+          method: :get
         ) if show_action? :reactivate, resource %>
       <% end %>
     </p>

--- a/app/views/admin/admin_users/_resource.html.erb
+++ b/app/views/admin/admin_users/_resource.html.erb
@@ -1,0 +1,61 @@
+<tr class="govuk-table__row">
+  <th colspan="2" class="govuk-table__header govuk-!-padding-left-0" scope="col">
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-0 govuk-!-margin-top-5 float-left">
+      <%= resource.email %>
+    </h3>
+  </th>
+  <td colspan="1" class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-two-fifths" scope="col">
+    <p class="govuk-!-margin-top-5 govuk-!-margin-bottom-1 float-right govuk-body">
+      <% if valid_action? :show, collection_presenter.resource_name %>
+        <%= link_to t('admin.actions.view_details'), polymorphic_path([namespace, resource]),
+          class: %w[govuk-!-padding-right-2] %>
+      <% end %>
+      <% if valid_action?(:edit, collection_presenter.resource_name) && show_action?(:edit, resource) %>
+        <%= link_to t('admin.actions.edit'), [:edit, namespace, resource],
+          class: %w[govuk-!-padding-right-2] %>
+      <% end %>
+      <% if resource.account_active? && valid_action?(:deactivate, collection_presenter.resource_name) %>
+        <%= link_to(
+          t("administrate.actions.deactivate"),
+          [:deactivate, namespace, resource],
+          class: "text-color-red",
+          method: :put,
+          data: { confirm: t("administrate.actions.confirm") }
+        ) if show_action? :deactivate, resource %>
+      <% end %>
+      <% if !resource.account_active? && valid_action?(:reactivate, collection_presenter.resource_name) %>
+        <%= link_to(
+          t("administrate.actions.reactivate"),
+          [:reactivate, namespace, resource],
+          class: "text-color-red",
+          method: :put,
+          data: { confirm: t("administrate.actions.confirm") }
+        ) if show_action? :reactivate, resource %>
+      <% end %>
+    </p>
+  </td>
+</tr>
+<tr>
+  <th colspan="1" class="govuk-table__cell govuk-!-padding-left-0 govuk-body govuk-!-font-weight-bold">
+    <%= t('admin.admin_users.sign_in_count') %>
+  </td>
+  <td colspan="2" data-label="<%= t('admin.admin_users.sign_in_count') %>" class="govuk-table__cell govuk-body">
+    <%= resource.sign_in_count %>
+  </td>
+</tr>
+<tr>
+  <th colspan="1" class="govuk-table__cell govuk-!-padding-left-0 govuk-body govuk-!-font-weight-bold">
+    <%= t('admin.admin_users.last_sign_in_at') %>
+  </td>
+  <td colspan="2" data-label="<%= t('admin.admin_users.last_sign_in_at') %>" class="govuk-table__cell govuk-body">
+    <%= resource.last_sign_in_at %>
+  </td>
+</tr>
+<tr>
+  <th colspan="1" class="govuk-table__cell govuk-!-padding-left-0 govuk-body govuk-!-font-weight-bold">
+    <%= t('admin.admin_users.last_sign_in_ip') %>
+  </td>
+  <td colspan="2" data-label="<%= t('admin.admin_users.last_sign_in_ip') %>" class="govuk-table__cell govuk-body">
+    <%= resource.last_sign_in_ip %>
+  </td>
+</tr>

--- a/app/views/admin/admin_users/deactivate_confirmation.html.erb
+++ b/app/views/admin/admin_users/deactivate_confirmation.html.erb
@@ -1,0 +1,59 @@
+<% content_for(:title) do %>
+  <%= t('admin.admin_users.actions.deactivate_confirmation', name: 'user') %>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-margin-top-0">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+    <%= render 'shared/admin/header' %>
+
+    <section class="main-content__body main-content__body--flush">
+      <div class="govuk-grid-row govuk-!-margin-top-3 govuk-!-padding-bottom-5">
+        <div class="govuk-grid-column-full">
+          <%= form_with url: [:deactivate, :admin, :admin_user], method: :put, local: true,
+            id: 'confirm-deactivate-form', data: { js_validate: true } do |f| -%>
+            <div id="form-group-deactivate" class="govuk-form-group">
+
+              <div class="error-message hidden">
+                <li data-reference="choice-error-deactivate" class="hidden">
+                  <a href="#choice-error-deactivate">You must select an option.</a>
+                </li>
+
+                <p id="choice-error-deactivate" class="govuk-error-message govuk-!-margin-top-2">
+                  <span class="govuk-visually-hidden">Error:</span>
+                  <span class="message">You must select an option.</span>
+                </p>
+              </div>
+
+              <div class="govuk-radios">
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input dataset-choice-radio"
+                         id="deactivate_yes"
+                         name="deactivate"
+                         type="radio" value="yes" required="true"
+                         data-js-validate-input="true">
+                  <label class="govuk-label govuk-radios__label" for="deactivate_yes">
+                    <%= t('admin.admin_users.actions.deactivate_confirmation_yes', name: page.resource.email) %>
+                  </label>
+                </div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input dataset-choice-radio"
+                         id="deactivate_no"
+                         name="deactivate"
+                         type="radio" value="no" required="true"
+                         data-js-validate-input="true">
+                  <label class="govuk-label govuk-radios__label" for="deactivate_no">
+                    <%= t('admin.admin_users.actions.deactivate_confirmation_no', name: page.resource.email) %>
+                  </label>
+                </div>
+              </div>
+            </div>
+            <button type="submit" class="govuk-button govuk-!-margin-bottom-3" id="submit-summary"
+                    name="submit" value="summary" data-submit="summary">
+              <%= t('forms.continue') %>
+            </button>
+          <%- end %>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>

--- a/app/views/admin/admin_users/index.html.erb
+++ b/app/views/admin/admin_users/index.html.erb
@@ -1,0 +1,51 @@
+<% content_for(:title) do %>
+  <%= t('admin.admin_users.title') %>
+<% end %>
+
+<%= render 'shared/admin/header' %>
+
+<section class="main-content__body main-content__body--flush">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-2">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full govuk-!-margin-bottom-2">
+          <%= render(
+            'search',
+            search_term: search_term,
+            resource_name: t('admin.admin_users.element').downcase
+          ) %>
+        </div>
+      </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+          <% if resources.any? -%>
+            <%= render(
+              "collection",
+              collection_presenter: page,
+              collection_field_name: resource_name,
+              page: page,
+              resources: resources,
+              table_title: "page-title"
+            ) %>
+          <%- else -%>
+            <p><%= t('admin.admin_users.no_admin_users') %></p>
+          <%- end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
+      <div class="govuk-top-border">
+        <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
+          <%= t('actions.actions') %>
+        </p>
+        <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
+          <%= link_to(t('admin.admin_users.actions.create'),
+                      [:new, :admin, :admin_user],
+                      class: %w[govuk-!-margin-bottom-1]
+                     ) if valid_action?(:new) && show_action?(:new, AdminUser.new) %>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/admin/admin_users/reactivate_confirmation.html.erb
+++ b/app/views/admin/admin_users/reactivate_confirmation.html.erb
@@ -1,0 +1,59 @@
+<% content_for(:title) do %>
+  <%= t('admin.admin_users.actions.reactivate_confirmation', name: 'user') %>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-margin-top-0">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+    <%= render 'shared/admin/header' %>
+
+    <section class="main-content__body main-content__body--flush">
+      <div class="govuk-grid-row govuk-!-margin-top-3 govuk-!-padding-bottom-5">
+        <div class="govuk-grid-column-full">
+          <%= form_with url: [:reactivate, :admin, :admin_user], method: :put, local: true,
+            id: 'confirm-reactivate-form', data: { js_validate: true } do |f| -%>
+            <div id="form-group-reactivate" class="govuk-form-group">
+
+              <div class="error-message hidden">
+                <li data-reference="choice-error-reactivate" class="hidden">
+                  <a href="#choice-error-reactivate">You must select an option.</a>
+                </li>
+
+                <p id="choice-error-reactivate" class="govuk-error-message govuk-!-margin-top-2">
+                  <span class="govuk-visually-hidden">Error:</span>
+                  <span class="message">You must select an option.</span>
+                </p>
+              </div>
+
+              <div class="govuk-radios">
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input dataset-choice-radio"
+                         id="reactivate_yes"
+                         name="reactivate"
+                         type="radio" value="yes" required="true"
+                         data-js-validate-input="true">
+                  <label class="govuk-label govuk-radios__label" for="reactivate_yes">
+                    <%= t('admin.admin_users.actions.reactivate_confirmation_yes', name: page.resource.email) %>
+                  </label>
+                </div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input dataset-choice-radio"
+                         id="reactivate_no"
+                         name="reactivate"
+                         type="radio" value="no" required="true"
+                         data-js-validate-input="true">
+                  <label class="govuk-label govuk-radios__label" for="reactivate_no">
+                    <%= t('admin.admin_users.actions.reactivate_confirmation_no', name: page.resource.email) %>
+                  </label>
+                </div>
+              </div>
+            </div>
+            <button type="submit" class="govuk-button govuk-!-margin-bottom-3" id="submit-summary"
+                    name="submit" value="summary" data-submit="summary">
+              <%= t('forms.continue') %>
+            </button>
+          <%- end %>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>

--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -104,26 +104,6 @@
           <%= link_to t('admin.admin_users.actions.edit'), [:edit, namespace, resource]%>
         <% end %>
       </p>
-      <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
-        <% if resource.account_active? %>
-          <%= link_to(
-            t('admin.admin_users.actions.deactivate'),
-            [:deactivate, namespace, resource],
-            class: "text-color-red",
-            method: :put,
-            data: { confirm: t("administrate.actions.confirm") }
-          ) if show_action? :deactivate, resource %>
-        <% end %>
-        <% if !resource.account_active? %>
-          <%= link_to(
-            t('admin.admin_users.actions.reactivate'),
-            [:reactivate, namespace, resource],
-            class: "text-color-red",
-            method: :put,
-            data: { confirm: t("administrate.actions.confirm") }
-          ) if show_action? :reactivate, resource %>
-        <% end %>
-      </p>
     </div>
   </div>
 </div>

--- a/app/views/admin/admin_users/show.html.erb
+++ b/app/views/admin/admin_users/show.html.erb
@@ -1,0 +1,129 @@
+<% resource = page.resource %>
+<% content_for(:title) do %>
+  <%= t('admin.admin_users.show') %>
+<% end %>
+
+<div class="govuk-grid-row govuk-!-margin-top-0">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+    <%= render 'shared/admin/header' %>
+
+    <section class="main-content__body main-content__body--flush">
+      <table aria-labelledby="<%= resource.email %>" class="govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+        <tbody>
+          <tr class="govuk-table__row">
+            <th colspan="2" class="govuk-table__header govuk-!-padding-left-0" scope="col">
+              <h3 class="govuk-heading-m govuk-!-margin-bottom-0 govuk-!-margin-top-5 float-left">
+                <%= resource.email %>
+              </h3>
+            </th>
+          </tr>
+          <tr>
+            <th class="govuk-table__cell govuk-!-padding-left-0 govuk-body govuk-!-font-weight-bold">
+              <%= t('admin.admin_users.id') %>
+            </td>
+            <td data-label="<%= t('admin.admin_users.id') %>" class="govuk-table__cell govuk-body">
+              <%= resource.id %>
+            </td>
+          </tr>
+          <tr>
+            <th class="govuk-table__cell govuk-!-padding-left-0 govuk-body govuk-!-font-weight-bold">
+              <%= t('admin.admin_users.deactivated_at') %>
+            </td>
+            <td data-label="<%= t('admin.admin_users.deactivated_at') %>" class="govuk-table__cell govuk-body">
+              <%= resource.deactivated_at || 'N/A' %>
+            </td>
+          </tr>
+          <tr>
+            <th class="govuk-table__cell govuk-!-padding-left-0 govuk-body govuk-!-font-weight-bold">
+              <%= t('admin.admin_users.sign_in_count') %>
+            </td>
+            <td data-label="<%= t('admin.admin_users.sign_in_count') %>" class="govuk-table__cell govuk-body">
+              <%= resource.sign_in_count %>
+            </td>
+          </tr>
+          <tr>
+            <th class="govuk-table__cell govuk-!-padding-left-0 govuk-body govuk-!-font-weight-bold">
+              <%= t('admin.admin_users.latest_sign_in_at') %>
+            </td>
+            <td data-label="<%= t('admin.admin_users.latest_sign_in_at') %>" class="govuk-table__cell govuk-body">
+              <%= resource.current_sign_in_at %>
+            </td>
+          </tr>
+          <tr>
+            <th class="govuk-table__cell govuk-!-padding-left-0 govuk-body govuk-!-font-weight-bold">
+              <%= t('admin.admin_users.previous_sign_in_at') %>
+            </td>
+            <td data-label="<%= t('admin.admin_users.previous_sign_in_at') %>" class="govuk-table__cell govuk-body">
+              <%= resource.last_sign_in_at %>
+            </td>
+          </tr>
+          <tr>
+            <th class="govuk-table__cell govuk-!-padding-left-0 govuk-body govuk-!-font-weight-bold">
+              <%= t('admin.admin_users.latest_sign_in_ip') %>
+            </td>
+            <td data-label="<%= t('admin.admin_users.latest_sign_in_ip') %>" class="govuk-table__cell govuk-body">
+              <%= resource.current_sign_in_ip %>
+            </td>
+          </tr>
+          <tr>
+            <th class="govuk-table__cell govuk-!-padding-left-0 govuk-body govuk-!-font-weight-bold">
+              <%= t('admin.admin_users.previous_sign_in_ip') %>
+            </td>
+            <td data-label="<%= t('admin.admin_users.previous_sign_in_ip') %>" class="govuk-table__cell govuk-body">
+              <%= resource.last_sign_in_ip %>
+            </td>
+          </tr>
+          <tr>
+            <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
+              <%= t('admin.admin_users.created_at') %>
+            </td>
+            <td colspan="3" data-label="<%= t('admin.admin_users.created_at') %>" class="govuk-table__cell govuk-body">
+              <%= I18n.localize(resource.created_at.in_time_zone('GB'), format: :default ) %>
+            </td>
+          </tr>
+          <tr>
+            <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-third govuk-body govuk-!-font-weight-bold">
+              <%= t('admin.admin_users.updated_at') %>
+            </td>
+            <td colspan="3" data-label="<%= t('admin.admin_users.updated_at') %>" class="govuk-table__cell govuk-body">
+              <%= I18n.localize(resource.updated_at.in_time_zone('GB'), format: :default ) %>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </div>
+
+  <div class="govuk-grid-column-one-third govuk-!-margin-top-9">
+    <div class="govuk-top-border">
+      <p class="govuk-heading-s govuk-!-font-size-19 govuk-!-padding-top-4">
+        <%= t('actions.actions') %>
+      </p>
+      <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
+        <% if valid_action?(:edit, 'admin_user') && show_action?(:edit, resource) %>
+          <%= link_to t('admin.admin_users.actions.edit'), [:edit, namespace, resource]%>
+        <% end %>
+      </p>
+      <p class="govuk-!-padding-0 govuk-!-margin-bottom-1">
+        <% if resource.account_active? %>
+          <%= link_to(
+            t('admin.admin_users.actions.deactivate'),
+            [:deactivate, namespace, resource],
+            class: "text-color-red",
+            method: :put,
+            data: { confirm: t("administrate.actions.confirm") }
+          ) if show_action? :deactivate, resource %>
+        <% end %>
+        <% if !resource.account_active? %>
+          <%= link_to(
+            t('admin.admin_users.actions.reactivate'),
+            [:reactivate, namespace, resource],
+            class: "text-color-red",
+            method: :put,
+            data: { confirm: t("administrate.actions.confirm") }
+          ) if show_action? :reactivate, resource %>
+        <% end %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/application/_search.html.erb
+++ b/app/views/admin/application/_search.html.erb
@@ -6,7 +6,7 @@
       </label>
     </div>
     <div class="govuk-flex-search">
-      <input class="search__input govuk-input govuk-!-width-two-thirds"
+      <input class="search__input govuk-input"
              id="search"
              name="search"
              type="search"

--- a/app/views/admin/application/edit.html.erb
+++ b/app/views/admin/application/edit.html.erb
@@ -1,36 +1,11 @@
-<%#
-# Edit
-
-This view is the template for the edit page.
-
-It displays a header, and renders the `_form` partial to do the heavy lifting.
-
-## Local variables:
-
-- `page`:
-  An instance of [Administrate::Page::Form][1].
-  Contains helper methods to help display a form,
-  and knows which attributes should be displayed in the resource's form.
-
-[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
-%>
-
 <% content_for(:title) { t("administrate.actions.edit_resource", name: page.page_title) } %>
 
-<header class="main-content__header" role="banner">
-  <h1 class="main-content__page-title">
-    <%= content_for(:title) %>
-  </h1>
+<div class="govuk-grid-row govuk-!-margin-top-0">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+    <%= render 'shared/admin/header' %>
 
-  <div>
-    <%= link_to(
-      t("administrate.actions.show_resource", name: page.page_title),
-      [namespace, page.resource],
-      class: "button",
-    ) if valid_action?(:show) && show_action?(:show, page.resource) %>
+    <section class="main-content__body main-content__body--flush">
+      <%= render "form", page: page %>
+    </section>
   </div>
-</header>
-
-<section class="main-content__body">
-  <%= render "form", page: page %>
-</section>
+</div>

--- a/app/views/admin/application/new.html.erb
+++ b/app/views/admin/application/new.html.erb
@@ -5,12 +5,12 @@
   ) %>
 <% end %>
 
-<header class="main-content__header" role="banner">
-  <h1 class="main-content__page-title">
-    <%= content_for(:title) %>
-  </h1>
-</header>
+<div class="govuk-grid-row govuk-!-margin-top-0">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+    <%= render 'shared/admin/header' %>
 
-<section class="main-content__body">
-  <%= render 'form', page: page %>
-</section>
+    <section class="main-content__body main-content__body--flush">
+      <%= render "form", page: page %>
+    </section>
+  </div>
+</div>

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title) do %>
-  Sort Categories and Concepts
+  <%= t('admin.categories.titles.sort') %>
 <% end %>
 
 <% content_for(:additional_tags) do %>

--- a/app/views/admin/concepts/_resource.html.erb
+++ b/app/views/admin/concepts/_resource.html.erb
@@ -20,7 +20,7 @@
   <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-quarter govuk-body govuk-!-font-weight-bold">
     <%= t('admin.categories.description') %>
   </td>
-  <td colspan="4" data-label="Description" class="govuk-table__cell govuk-body">
+  <td colspan="4" data-label="<%= t('admin.categories.description') %>" class="govuk-table__cell govuk-body">
     <%= resource.description %>
   </td>
 </tr> -->
@@ -47,7 +47,7 @@
   <th class="govuk-table__cell govuk-!-padding-left-0 govuk-!-width-one-quarter govuk-body govuk-!-font-weight-bold">
     <%= t('admin.concepts.data_items') %>
   </td>
-  <td colspan="4" data-label="Data Items" class="govuk-table__cell govuk-body">
+  <td colspan="4" data-label="<%= t('admin.concepts.data_items') %>" class="govuk-table__cell govuk-body">
     <%= resource.data_elements.count %>
   </td>
 </tr>

--- a/app/views/admin/data_elements/index.html.erb
+++ b/app/views/admin/data_elements/index.html.erb
@@ -6,7 +6,7 @@
 
 <section class="main-content__body main-content__body--flush">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full govuk-!-margin-bottom-2">
+    <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-2">
       <%= render(
         'search',
         search_term: search_term,

--- a/app/views/admin/uploads/_thead.html.erb
+++ b/app/views/admin/uploads/_thead.html.erb
@@ -1,5 +1,5 @@
 <thead>
-  <tr class="govuk-table__row">
+  <tr class="govuk-table__row" scope="row">
     <th class="cell-label govuk-table__header govuk-!-padding-left-0" scope="col">File Name</th>
     <th class="cell-label govuk-table__header" scope="col">Uploaded By</th>
     <th class="cell-label govuk-table__header" scope="col">Uploaded At</th>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,8 +2,8 @@
   Edit <%= resource_name.to_s.humanize %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+<div class="govuk-grid-row govuk-!-margin-top-0">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0 govuk-!-margin-bottom-5">
     <div class="govuk-breadcrumbs">
       <ol class="govuk-breadcrumbs__list">
         <li class="govuk-breadcrumbs__list-item">
@@ -11,31 +11,21 @@
         </li>
       </ol>
     </div>
-  </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <header class="main-content__header" role="banner">
-      <h1 class="main-content__page-title" id="page-title">
+    <header class="main-content__header govuk-!-padding-left-0 govuk-!-border-0" role="banner">
+      <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-1" id="page-title">
         <%= content_for(:title) %>
       </h1>
     </header>
 
-    <fieldset class="govuk-fieldset govuk-grid-row govuk-!-margin-2">
-      <div class="govuk-grid-column-two-thirds">
+    <section class="main-content__body main-content__body--flush">
+      <fieldset class="govuk-fieldset govuk-!-margin-left-0">
         <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
           <%= render "devise/shared/error_messages", resource: resource %>
           <%= render 'devise/shared/flash_messages' %>
 
           <div class="govuk-form-group">
-            <%= f.label :email, class: 'govuk-label' %>
-            <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'govuk-input', disabled: true %>
-            <% if f.object.errors[:email].present? %>
-              <span class="govuk-error-message">
-                <span class="govuk-visually-hidden">Error:</span> <%= f.object.errors[:email].map(&:capitalize).join(', ') %>
-              </span>
-            <% end %>
+            <h2 class="govuk-heading-m"><%= resource.email %></h2>
           </div>
 
           <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
@@ -43,12 +33,11 @@
           <% end %>
 
           <div class="govuk-form-group">
-            <%= f.label :password, class: 'govuk-label' %>
-            <div class="govuk-hint">(leave blank if you don't want to change it)</div>
-            <%= f.password_field :password, autocomplete: 'new-password', class: 'govuk-input' %>
+            <%= f.label :password, t('admin.admin_users.password_and_hint'), class: 'govuk-label' %>
             <% if @minimum_password_length %>
               <div class="govuk-hint"><%= t('devise.passwords.format', length: @minimum_password_length) %></div>
             <% end %>
+            <%= f.password_field :password, autocomplete: 'new-password', class: 'govuk-input' %>
             <% if f.object.errors[:password].present? %>
               <span class="govuk-error-message">
                 <span class="govuk-visually-hidden">Error:</span> <%= f.object.errors[:password].map(&:capitalize).join(', ') %>
@@ -57,7 +46,7 @@
           </div>
 
           <div class="govuk-form-group">
-            <%= f.label :password_confirmation, class: 'govuk-label' %>
+            <%= f.label :password_confirmation, t('admin.admin_users.password_confirmation'), class: 'govuk-label' %>
             <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'govuk-input' %>
             <% if f.object.errors[:password_confirmation].present? %>
               <span class="govuk-error-message">
@@ -67,8 +56,8 @@
           </div>
 
           <div class="govuk-form-group">
-            <%= f.label :current_password, class: 'govuk-label' %>
-            <div class="govuk-hint">(we need your current password to confirm your changes)</div>
+            <%= f.label :current_password, t('admin.admin_users.current_password'), class: 'govuk-label' %>
+            <div class="govuk-hint"><%= t('admin.admin_users.current_password_hint') %></div>
             <%= f.password_field :current_password, autocomplete: 'current-password', class: 'govuk-input' %>
             <% if f.object.errors[:current_password].present? %>
               <span class="govuk-error-message">
@@ -77,11 +66,12 @@
             <% end %>
           </div>
 
-          <div class="govuk-form-group actions">
-            <%= f.submit 'Update', class: 'govuk-button' %>
+          <div class="form-actions govuk--form-actions">
+            <%= f.button type: :submit, class: %w[govuk-button] %>
+            <%= link_to 'Cancel', [:admin, resource], class: %w[govuk-button govuk-button--secondary] %>
           </div>
         <% end %>
-      </div>
-    </fieldset>
+      </fieldset>
+    </section>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,6 +363,7 @@ en:
       previous_sign_in_ip: Previous sign in IP
       created_at: Created at
       updated_at: Updated at
+      password: Password
       password_and_hint: Password (leave blank if you don't want to change it)
       password_confirmation: Password confirmation
       current_password: Password

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -344,6 +344,12 @@ en:
         edit: Edit admin user
         deactivate: Deactivate admin user
         reactivate: Reactivate admin user
+        deactivate_confirmation: "Deactivate %{name}?"
+        deactivate_confirmation_yes: "Yes, deactivate %{name}"
+        deactivate_confirmation_no: "No, do not deactivate %{name}"
+        reactivate_confirmation: "Reactivate %{name}?"
+        reactivate_confirmation_yes: "Yes, reactivate %{name}"
+        reactivate_confirmation_no: "No, do not reactivate %{name}"
       active: Active Admin Users
       inactive: Inactive Admin Users
       id: ID
@@ -362,6 +368,8 @@ en:
       current_password: Password
       current_password_hint: We need your current password to confirm your changes
       no_admin_users: No admin users. How are you even seeing this page?
+      deactivate_aborted: "%{name} not deactivated. Action cancelled by user."
+      reactivate_aborted: "%{name} not reactivated. Action cancelled by user."
   forms:
     continue: Continue
     confirm: Confirm

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,6 +357,10 @@ en:
       previous_sign_in_ip: Previous sign in IP
       created_at: Created at
       updated_at: Updated at
+      password_and_hint: Password (leave blank if you don't want to change it)
+      password_confirmation: Password confirmation
+      current_password: Password
+      current_password_hint: We need your current password to confirm your changes
       no_admin_users: No admin users. How are you even seeing this page?
   forms:
     continue: Continue

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -341,11 +341,22 @@ en:
       show: View admin user
       actions:
         create: Create a new admin user
+        edit: Edit admin user
+        deactivate: Deactivate admin user
+        reactivate: Reactivate admin user
       active: Active Admin Users
       inactive: Inactive Admin Users
+      id: ID
+      deactivated_at: Deactivated at
       sign_in_count: Sign in count
       last_sign_in_at: Last sign in at
       last_sign_in_ip: Last sign in IP
+      latest_sign_in_at: Latest sign in at
+      latest_sign_in_ip: Latest sign in IP
+      previous_sign_in_at: Previous sign in at
+      previous_sign_in_ip: Previous sign in IP
+      created_at: Created at
+      updated_at: Updated at
       no_admin_users: No admin users. How are you even seeing this page?
   forms:
     continue: Continue

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,6 +198,7 @@ en:
         delete: Delete category
         expand_all: Expand all categories
       titles:
+        sort: Sort Categories and Concepts
         childless: Childless Categories
       no_childless_categories: No childless categories found
       confirm_delete: This category will be deleted permanently. Are you sure?
@@ -334,6 +335,18 @@ en:
       data_tables: Data Table Uploads
       information_architecture: Categories and Concepts Uploads
       breadcrumbs: Recent uploads
+    admin_users:
+      element: Admin users
+      title: Manage admin users
+      show: View admin user
+      actions:
+        create: Create a new admin user
+      active: Active Admin Users
+      inactive: Inactive Admin Users
+      sign_in_count: Sign in count
+      last_sign_in_at: Last sign in at
+      last_sign_in_ip: Last sign in IP
+      no_admin_users: No admin users. How are you even seeing this page?
   forms:
     continue: Continue
     confirm: Confirm

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,7 +62,11 @@ Rails.application.routes.draw do
     resources :datasets
     resources :admin_users
     resource :admin_user, only: [] do
+      get  ':id/deactivate_confirmation', to: 'admin_users#deactivate_confirmation',
+        as: :deactivate_confirmation
       put ':id/deactivate', to: 'admin_users#deactivate', as: :deactivate
+      get  ':id/reactivate_confirmation', to: 'admin_users#reactivate_confirmation',
+        as: :reactivate_confirmation
       put ':id/reactivate', to: 'admin_users#reactivate', as: :reactivate
     end
     resources :uploads, only: %i[index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,10 +62,10 @@ Rails.application.routes.draw do
     resources :datasets
     resources :admin_users
     resource :admin_user, only: [] do
-      get  ':id/deactivate_confirmation', to: 'admin_users#deactivate_confirmation',
+      get ':id/deactivate_confirmation', to: 'admin_users#deactivate_confirmation',
         as: :deactivate_confirmation
       put ':id/deactivate', to: 'admin_users#deactivate', as: :deactivate
-      get  ':id/reactivate_confirmation', to: 'admin_users#reactivate_confirmation',
+      get ':id/reactivate_confirmation', to: 'admin_users#reactivate_confirmation',
         as: :reactivate_confirmation
       put ':id/reactivate', to: 'admin_users#reactivate', as: :reactivate
     end


### PR DESCRIPTION
# Admin Area: redesign 'Manage admin users' pages

## Development

Redesign the "manage admin users" area to make it more user friendly

## Screenshots 

### Index page

![01_list_admin_users](https://user-images.githubusercontent.com/2742327/113606717-48e56a80-9640-11eb-907f-a71d4a208a85.jpg)

### Details page for an active user

![02_admin_user_details_active](https://user-images.githubusercontent.com/2742327/113606743-50a50f00-9640-11eb-9b3d-5a3b5d48a364.jpg)

### Details page for an inactive user

![03_admin_user_details_inactive](https://user-images.githubusercontent.com/2742327/113606759-5864b380-9640-11eb-833b-3113bedf56c8.jpg)

### Edit user page

![04_admin_user_edit](https://user-images.githubusercontent.com/2742327/113606780-5dc1fe00-9640-11eb-9462-a02a8e9f9794.jpg)

### New user page

![05_admin_user_new](https://user-images.githubusercontent.com/2742327/113607240-e476db00-9640-11eb-9527-fd02f5435b2f.jpg)

### Deactivate confirmation page

![06_admin_user_deactivate](https://user-images.githubusercontent.com/2742327/113606827-6ca8b080-9640-11eb-8b64-8c81eb541445.jpg)

### Reactivate confirmation page

![07_admin_user_reactivate](https://user-images.githubusercontent.com/2742327/113606849-729e9180-9640-11eb-995c-03a49f016052.jpg)
