### PR TITLE
Fix header width in admin area

### DIFF
--- a/app/views/admin/categories/export.html.erb
+++ b/app/views/admin/categories/export.html.erb
@@ -10,29 +10,33 @@
   <%= javascript_pack_tag 'category_download' %>
 <% end %>
 
-<%= render 'shared/admin/header' %>
+<div class="govuk-grid-row govuk-!-margin-top-0">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+    <%= render 'shared/admin/header' %>
 
-<fieldset class="govuk-fieldset govuk-!-margin-0" aria-describedby="download-file-hint download-file-error" role="group">
-  <%= link_to t('forms.continue'), download_admin_categories_path, class: 'govuk-button govuk-!-margin-left-0', id: 'download-link' %>
-</fieldset>
-<div id="govuk-box-container">
-  <h2 class="govuk-heading-l govuk-align-center"><%= t('admin.categories.export.creating').html_safe %></h2>
-  <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
-</div>
-<div id="govuk-box-success">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <div class="govuk-panel govuk-panel--confirmation">
-        <h2 class="govuk-panel__title">
-          <%= t('admin.categories.export.created.title').html_safe %>
-        </h2>
+    <fieldset class="govuk-fieldset govuk-!-margin-0" aria-describedby="download-file-hint download-file-error" role="group">
+      <%= link_to t('forms.continue'), download_admin_categories_path, class: 'govuk-button govuk-!-margin-left-0', id: 'download-link' %>
+    </fieldset>
+    <div id="govuk-box-container">
+      <h2 class="govuk-heading-l govuk-align-center"><%= t('admin.categories.export.creating').html_safe %></h2>
+      <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
+    </div>
+    <div id="govuk-box-success">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <div class="govuk-panel govuk-panel--confirmation">
+            <h2 class="govuk-panel__title">
+              <%= t('admin.categories.export.created.title').html_safe %>
+            </h2>
+          </div>
+          <p class="govuk-body">
+            <%= t('admin.categories.export.created.subtitle').html_safe %>
+          </p>
+          <p class="govuk-body">
+            <%= link_to t('forms.continue_to_home'), admin_root_path %>
+          </p>
+        </div>
       </div>
-      <p class="govuk-body">
-        <%= t('admin.categories.export.created.subtitle').html_safe %>
-      </p>
-      <p class="govuk-body">
-        <%= link_to t('forms.continue_to_home'), admin_root_path %>
-      </p>
     </div>
   </div>
 </div>

--- a/app/views/admin/categories/import.html.erb
+++ b/app/views/admin/categories/import.html.erb
@@ -8,12 +8,16 @@
   <%= javascript_pack_tag 'category_upload' %>
 <% end %>
 
-<%= render 'shared/admin/header' %>
+<div class="govuk-grid-row govuk-!-margin-top-0">
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0 govuk-!-margin-bottom-5">
+    <%= render 'shared/admin/header' %>
 
-<fieldset class="govuk-fieldset govuk-!-margin-0" aria-describedby="upload-file-hint upload-file-error" role="group">
-  <%= render partial: 'import_form', locals: { success: success, errors: errors } %>
-</fieldset>
-<div id="govuk-box-container">
-  <h2 class="govuk-heading-l govuk-align-center"><%= t('admin.categories.export.creating').html_safe %></h2>
-  <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
+    <fieldset class="govuk-fieldset govuk-!-margin-0" aria-describedby="upload-file-hint upload-file-error" role="group">
+      <%= render partial: 'import_form', locals: { success: success, errors: errors } %>
+    </fieldset>
+    <div id="govuk-box-container">
+      <h2 class="govuk-heading-l govuk-align-center"><%= t('admin.categories.export.creating').html_safe %></h2>
+      <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
+    </div>
+  </div>
 </div>

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -11,13 +11,7 @@
 
 <div class="govuk-grid-row govuk-!-margin-top-0">
   <div class="govuk-grid-column-two-thirds govuk-!-margin-top-0">
-    <header class="main-content__header govuk-!-padding-left-0 govuk-!-border-0" role="banner">
-      <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-        <h1 class="govuk-heading-l govuk-!-margin-top-2 govuk-!-margin-bottom-3" id="page-title">
-          <%= content_for(:title) %>
-        </h1>
-      </div>
-    </header>
+    <%= render 'shared/admin/header' %>
 
     <section id="nestable" class="main-content__body main-content__body--flush">
       <% if @categories.present? %>

--- a/app/views/admin/data_elements/_data_element.html.erb
+++ b/app/views/admin/data_elements/_data_element.html.erb
@@ -11,7 +11,7 @@
   <td data-label="<%= t('admin.data_elements.datasets') %>" class="govuk-table__cell right" scope="col">
     <%= data_element.datasets.count %>
   </td>
-  <td data-label="<%= t('admin.actions.view_details') %>" class="govuk-table__cell govuk-!-padding-right-0 right" scope="col">
+  <td data-label="<%= t('admin.actions.view_details') %>" class="govuk-table__cell govuk-!-padding-right-0 right no-break" scope="col">
     <%= link_to t('admin.actions.view_details'),
                 [:admin, data_element],
                 { class: 'action-show' } %>

--- a/app/views/admin/data_elements/reindex.html.erb
+++ b/app/views/admin/data_elements/reindex.html.erb
@@ -5,11 +5,12 @@
   <%= t('admin.data_elements.reindex.description') %>
 <% end %>
 
-<%= render 'shared/admin/header' %>
 
 <section class="main-content__body main-content__body--flush">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-2">
+      <%= render 'shared/admin/header' %>
+
       <fieldset class="govuk-fieldset govuk-!-margin-top-5" aria-describedby="reindex-hint reindex-error" role="group">
         <div id="form-group" class="govuk-form-group<%= success == false ? ' govuk-form-group--error' : '' %>">
           <%= form_with url: reindex_admin_data_elements_path, method: :post, id: 'reindex-form', data: { remote: false } do |f| %>

--- a/app/views/shared/admin/_header.html.erb
+++ b/app/views/shared/admin/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="main-content__header govuk-!-padding-left-0 govuk-!-border-0" role="banner">
-  <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
+  <div class="govuk-grid-column-full govuk-!-padding-left-0">
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-1" id="page-title">
       <%= content_for(:title) %>
     </h1>


### PR DESCRIPTION
# Fix header width in admin area

## Problem

When viewing the ‘View details’ page for categories, concepts, data items, datasets, the header wraps tightly an doesn’t stretch across the top of the column.

## Development

The design seems to indicate that the header should only occupy two thirds of the top column, with the remaining third reserved for the action side bar.

The issue was that the header was occupying _a lot less_ than two third of the page, and the headers has been fixed to stretch through the whole allocated two-thirds.

## Screenshots

### Concept detail

<img width="1077" alt="Screen Shot 2021-04-22 at 12 34 09" src="https://user-images.githubusercontent.com/2742327/115709284-f35fcc00-a368-11eb-9e3d-74a365ebb739.png">

### Category detail

<img width="1020" alt="Screen Shot 2021-04-22 at 12 34 44" src="https://user-images.githubusercontent.com/2742327/115709301-fa86da00-a368-11eb-863e-a03064c16b68.png">

### Dataset detail

<img width="1014" alt="Screen Shot 2021-04-22 at 12 39 04" src="https://user-images.githubusercontent.com/2742327/115709329-04a8d880-a369-11eb-8909-16784445af1b.png">

### Data item detail

Since data item names don't have white spaces (which is the character that is usually considered safe for breaking), the very long ones tend to break through the normal allocated width.
This is a rather extreme example, is it OK? 

![data_item](https://user-images.githubusercontent.com/2742327/115709575-46d21a00-a369-11eb-81fd-f83aedc69775.jpg)
