### PR TITLE
Dev #737: Change text on 'My List' page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,7 +106,7 @@ en:
       elements_saved: items saved
     my_list:
       title: My List
-      description: You can export this list of data items into a .xlsx or .ods file.
+      description: "As you explore information about the type of data held in the NPD, you can create a 'My List' of data items that are of interest to you. You can export this list into a .xlsx or .ods file, which may help when completing the NPD Data Tables that should be submitted when applying to DfE for NPD data."
       link: applying for access
       no_elements: You currently have no items saved in your list
       additional_notes: Additional notes

--- a/spec/system/saved_items_page_spec.rb
+++ b/spec/system/saved_items_page_spec.rb
@@ -5,9 +5,13 @@ require 'rails_helper'
 RSpec.describe 'Saved Items page', type: :system do
   it 'Will show the saved items page' do
     visit '/saved_items'
-    expect(page).to have_text('My List', count: 2)
+    expect(page).to have_text('My List', count: 3)
     expect(page).to have_text(
-      'You can export this list of data items into a .xlsx or .ods file.'
+      'As you explore information about the type of data held in the NPD, ' \
+      'you can create a \'My List\' of data items that are of interest to you. ' \
+      'You can export this list into a .xlsx or .ods file, which may help when ' \
+      'completing the NPD Data Tables that should be submitted when applying to ' \
+      'DfE for NPD data.'
     )
   end
 


### PR DESCRIPTION
# Change text on 'My List' page

An NPD data sharing caseworker (Martin Johnson) reported that an applicant tried to submit the output from their 'My List' with their data sharing application. On being informed they had to submit the Data Tables instead, they pointed out that there wasn't anything on the My List page that informed them not to use their My List as part of their data sharing application, and that they'd spent a full day compiling their My List.

To avoid this happening, the wording on the My List page, under the 'My List' header, that currently states 'You can export this list of data items into a .xlsx or .ods file', should be changed to 'As you explore information about the type of data held in the NPD, you can create a ‘My List’ of data items that are of interest to you. You can export this list into a .xlsx or .ods file, which may help when completing the NPD Data Tables that should be submitted when applying to DfE for NPD data.’

## Development

Amended the wording as requested

## Screenshot

<img width="796" alt="Screen Shot 2021-05-15 at 08 20 18" src="https://user-images.githubusercontent.com/2742327/118353330-adf48000-b55d-11eb-9174-28aae333f609.png">
