### PR TITLE
Dev #696 - Admin: fix ordering of categories after IA file import on live environment

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -86,7 +86,7 @@ module Admin
       loader = InfArch::Upload.create(admin_user: current_admin_user,
                                       file_name: params['file-upload'].original_filename,
                                       data_table: params['file-upload'])
-      loader.data_table.attach(params['file-upload'])
+      loader.data_table.attach(params['file-upload']) unless loader.data_table.attached?
       loader.preprocess
 
       render partial: 'preprocess', layout: false, locals: { loader: loader }

--- a/app/controllers/admin/import_datasets_controller.rb
+++ b/app/controllers/admin/import_datasets_controller.rb
@@ -18,7 +18,7 @@ module Admin
       loader = DataTable::Upload.create(admin_user: current_admin_user,
                                         file_name: params['file-upload'].original_filename,
                                         data_table: params['file-upload'])
-      loader.data_table.attach(params['file-upload'])
+      loader.data_table.attach(params['file-upload']) unless loader.data_table.attached?
       loader.preprocess
 
       if loader.data_table_tabs.recognised.any?

--- a/app/models/concerns/process_categories.rb
+++ b/app/models/concerns/process_categories.rb
@@ -25,7 +25,7 @@ module ProcessCategories
     end
 
     def process
-      upload(inf_arch_tabs.map(&:tree).flatten)
+      upload(inf_arch_tabs.map(&:tree).flatten.reverse)
 
       update(successful: true)
     end

--- a/app/models/data_table/upload.rb
+++ b/app/models/data_table/upload.rb
@@ -22,6 +22,7 @@ module DataTable
     def initialize(attr)
       @workbook = Roo::Spreadsheet.open(attr.delete(:data_table))
       super(attr)
+      self.data_table.attach(workbook)
     end
 
     def fast_cleanup

--- a/app/models/inf_arch/tab.rb
+++ b/app/models/inf_arch/tab.rb
@@ -25,6 +25,8 @@ module InfArch
   class Tab < ApplicationRecord
     include ProcessCategoryTabs
 
+    default_scope -> { order(created_at: :asc) }
+
     belongs_to :inf_arch_upload, class_name: 'InfArch::Upload', inverse_of: :inf_arch_tabs
 
     attr_reader :sheet, :categories_tree

--- a/app/models/inf_arch/upload.rb
+++ b/app/models/inf_arch/upload.rb
@@ -16,6 +16,7 @@ module InfArch
     def initialize(attr)
       @workbook = Roo::Spreadsheet.open(attr.delete(:data_table))
       super(attr)
+      self.data_table.attach(workbook)
     end
   end
 end


### PR DESCRIPTION
# Admin: fix ordering of categories after IA file import on live environment

As a F&E admin user
I want the Information Architecture file to reset the top level categories to the order they were in when the IA file was created
So that I don't have to re-order the top level categories after importing the Information Architecture file

## Testing

Tested locally and working.

The best way to test is to export the IA file from production, upload it into staging after deploy and verify if the order is the same.