### PR TITLE
Dev #740 - Admin pages: change text on 'Import categories and concepts backup file' page

### DIFF
--- a/app/javascript/packs/category_download.js
+++ b/app/javascript/packs/category_download.js
@@ -14,6 +14,9 @@ $(document).ready(function() {
     }
 
     $('#download-link').attr('disabled', true)
+    $('.main-content__header').hide()
+    $('fieldset').hide()
+    $('.govuk-breadcrumbs').hide()
     $('#govuk-box-container').show();
 
     window.loader.init({

--- a/app/javascript/packs/category_upload.js
+++ b/app/javascript/packs/category_upload.js
@@ -1,3 +1,6 @@
+import '../src/loader.scss'
+
+import displayLoader from '../src/loader-display.js'
 import $ from 'jquery'
 import '../src/govuk-frontend.js'
 
@@ -6,8 +9,12 @@ $(document).on('ajax:success', function(event) {
   var data = detail[0], status = detail[1], xhr = detail[2]
 
   setTimeout(function() {
-    $('#govuk-box-container').hide();
+    $('#govuk-box-container').hide()
+    $('.main-content__header').show()
+    $('fieldset').show()
+    $('.govuk-breadcrumbs').show()
     document.querySelector('#form-group').outerHTML = detail[0].body.innerHTML
     document.getElementById('submit-upload').removeAttribute('disabled')
+    $('.loader-on-submit').submit(displayLoader)
   }, 500)
 })

--- a/app/javascript/packs/loader.js
+++ b/app/javascript/packs/loader.js
@@ -1,25 +1,9 @@
 import '../src/loader.scss'
-import '../src/loader.js'
+import displayLoader from '../src/loader-display.js'
 import $ from 'jquery'
 
 window.loader = new GOVUK.Loader()
 
 $(document).ready(function() {
-  $('.loader-on-submit').submit(function(event) {
-    if ($(event.currentTarget).attr('disabled')) {
-      return;
-    }
-
-    $(event.currentTarget).parents('.govuk-form-group').removeClass('govuk-form-group--error');
-    $(event.currentTarget).find('.govuk-error-message').hide();
-    $('button').attr('disabled', true);
-    $('#govuk-box-container').show();
-
-    window.loader.init({
-      container: 'govuk-box-message',
-      label: true,
-      labelText: '',
-      size: '175px',
-    });
-  });
+  $('.loader-on-submit').submit(displayLoader);
 });

--- a/app/javascript/packs/select-to-link.js
+++ b/app/javascript/packs/select-to-link.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-tail = { select: require('tail.select') }
+var tail = { select: require('tail.select') }
 
 function hideSelect(element) {
   $(element).parent('.select').hide();

--- a/app/javascript/src/loader-display.js
+++ b/app/javascript/src/loader-display.js
@@ -1,0 +1,30 @@
+import '../src/loader.js'
+
+const displayLoader = function(event) {
+  if ($(event.currentTarget).attr('disabled')) {
+    return
+  }
+
+  const message = event.currentTarget.dataset.loaderMessage
+  $(event.currentTarget).parents('.govuk-form-group').removeClass('govuk-form-group--error')
+  $(event.currentTarget).find('.govuk-error-message').hide()
+  $('button').attr('disabled', true)
+  $('.main-content__header').hide()
+  $('fieldset').hide()
+  $('.govuk-breadcrumbs').hide()
+  if (message != undefined) {
+    $('#govuk-box-container').find('.govuk-heading-l').html(message)
+  }
+  $('#govuk-box-container').show()
+
+  if ($('#loader')[0] == undefined) {
+    window.loader.init({
+      container: 'govuk-box-message',
+      label: true,
+      labelText: '',
+      size: '175px',
+    })
+  }
+}
+
+export default displayLoader

--- a/app/javascript/src/loader.scss
+++ b/app/javascript/src/loader.scss
@@ -5,8 +5,6 @@
   display: none;
   height: 280px;
   left: auto;
-  position: fixed;
-  top: 170px;
   width: 100%;
   z-index: 1000;
 }

--- a/app/views/admin/categories/_import_form.html.erb
+++ b/app/views/admin/categories/_import_form.html.erb
@@ -1,6 +1,7 @@
 <div id="form-group" class="govuk-form-group<%= success == false ? ' govuk-form-group--error' : '' %>">
   <%= form_with url: preprocess_admin_categories_path, method: :post, remote: true,
-                class: %w[loader-on-submit], multipart: true, id: 'upload-form' do |f| %>
+                class: %w[loader-on-submit], multipart: true, id: 'upload-form',
+                data: { loader_message: t('admin.categories.import.import').html_safe } do |f| %>
     <label class="govuk-label govuk-!-margin-bottom-3" for="file-upload">
       <span class="govuk-body-m"><%= t('admin.categories.import.label') %></span>
     </label>

--- a/app/views/admin/categories/_preprocess.html.erb
+++ b/app/views/admin/categories/_preprocess.html.erb
@@ -26,12 +26,14 @@
     <% end %>
     <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
     <%= form_with url: import_admin_categories_path, method: :post, remote: true,
-                  multipart: true, id: 'upload-form', class: %w[loader-on-submit inline-form] do |f| %>
+                  multipart: true, id: 'upload-form', class: %w[loader-on-submit inline-form],
+                  data: { loader_message: t('admin.categories.import.import').html_safe } do |f| %>
       <input type="hidden" name="loader_id" value="<%= loader.id %>">
       <button type="submit" class="govuk-button" id="submit-upload">Confirm Upload</button>
     <%- end %>
-    <%= form_with url: abort_import_admin_categories_path, method: :post, remote: true,
-                  multipart: true, id: 'upload-form', class: %w[loader-on-submit inline-form] do |f| %>
+    <%= form_with url: abort_import_admin_categories_path, method: :post, remote: false,
+                  multipart: true, id: 'upload-form', class: %w[loader-on-submit inline-form],
+                  data: { loader_message: t('admin.categories.import.cancel').html_safe } do |f| %>
       <input type="hidden" name="loader_id" value="<%= loader.id %>">
       <button type="submit" class="govuk-button govuk-button--secondary" id="cancel-upload">Go Back</button>
     <%- end %>

--- a/app/views/admin/categories/export.html.erb
+++ b/app/views/admin/categories/export.html.erb
@@ -21,21 +21,21 @@
       <h2 class="govuk-heading-l govuk-align-center"><%= t('admin.categories.export.creating').html_safe %></h2>
       <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
     </div>
-    <div id="govuk-box-success">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <div class="govuk-panel govuk-panel--confirmation">
-            <h2 class="govuk-panel__title">
-              <%= t('admin.categories.export.created.title').html_safe %>
-            </h2>
-          </div>
-          <p class="govuk-body">
-            <%= t('admin.categories.export.created.subtitle').html_safe %>
-          </p>
-          <p class="govuk-body">
-            <%= link_to t('forms.continue_to_home'), admin_root_path %>
-          </p>
+  </div>
+  <div id="govuk-box-success">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+          <h2 class="govuk-panel__title">
+            <%= t('admin.categories.export.created.title').html_safe %>
+          </h2>
         </div>
+        <p class="govuk-body">
+          <%= t('admin.categories.export.created.subtitle').html_safe %>
+        </p>
+        <p class="govuk-body">
+          <%= link_to t('forms.continue_to_home'), admin_root_path %>
+        </p>
       </div>
     </div>
   </div>

--- a/app/views/admin/categories/import.html.erb
+++ b/app/views/admin/categories/import.html.erb
@@ -16,7 +16,7 @@
       <%= render partial: 'import_form', locals: { success: success, errors: errors } %>
     </fieldset>
     <div id="govuk-box-container">
-      <h2 class="govuk-heading-l govuk-align-center"><%= t('admin.categories.export.creating').html_safe %></h2>
+      <h2 class="govuk-heading-l govuk-align-center"><%= t('admin.categories.import.import').html_safe %></h2>
       <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
     </div>
   </div>

--- a/app/views/admin/import_datasets/_import_form.html.erb
+++ b/app/views/admin/import_datasets/_import_form.html.erb
@@ -16,7 +16,6 @@
         The file was processed and uploaded successfully
       </p>
     <%- end %>
-    <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
     <button type="submit" class="govuk-button" id="submit-upload">Continue</button>
   <%- end %>
 </div>

--- a/app/views/admin/import_datasets/import_start.html.erb
+++ b/app/views/admin/import_datasets/import_start.html.erb
@@ -20,3 +20,6 @@
 <fieldset class="govuk-fieldset govuk-!-margin-0" id="upload-file-container" aria-describedby="upload-file-hint upload-file-error" role="group">
   <%= render partial: 'import_form', locals: { success: success, error: error } %>
 </fieldset>
+<div id="govuk-box-container">
+  <div class="govuk-box govuk-!-margin-3" id="govuk-box-message" aria-busy="true"></div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,7 +209,8 @@ en:
       child_categories: Child categories
       import:
         title: Import categories and concepts backup file
-        label: Categories and concepts backup file to import
+        label: Select a categories and concepts backup file to import. Importing this file will overwrite the existing categories and concepts structure.
+        import: Importing categories and concepts<br/>backup file
       export:
         title: Create categories and concepts backup file
         subtitle: Create new categories and concepts backup file

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,6 +211,7 @@ en:
         title: Import categories and concepts backup file
         label: Select a categories and concepts backup file to import. Importing this file will overwrite the existing categories and concepts structure.
         import: Importing categories and concepts<br/>backup file
+        cancel: Cancelling categories and concepts<br/>backup file import
       export:
         title: Create categories and concepts backup file
         subtitle: Create new categories and concepts backup file
@@ -301,6 +302,7 @@ en:
         import:
           title: Choose a file to upload
           label: File to upload
+          loading: Importing datasets file
         recognised:
           title: Recognised datasets
           description: 'The following datasets have been recognised; select the datasets you wish to import:'


### PR DESCRIPTION
# Admin pages: change text on 'Import categories and concepts backup file' page

When an admin user decides to import a categories and concepts backup file, they should be informed that this will overwrite the existing categories and concepts structure.

## Development

On the 'Import categories and concepts backup file' page, under the page header the text currently states, 'Categories and concepts backup file to import'; this should be changed to, 'Select a categories and concepts backup file to import. Importing this file will overwrite the existing categories and concepts structure.'.

## Screenshot

<img width="790" alt="Screen Shot 2021-05-16 at 18 03 07" src="https://user-images.githubusercontent.com/2742327/118405752-197b4200-b671-11eb-82ce-1a3e85d48c74.png">
